### PR TITLE
Fixtures: Modularize the fixtures creating AiiDA instance and profile

### DIFF
--- a/.github/workflows/aws-s3.yml
+++ b/.github/workflows/aws-s3.yml
@@ -35,9 +35,6 @@ jobs:
         -   name: Install Python package and dependencies
             run: pip install -e .[tests]
 
-        -   name: Install custom `aiida-core` branch
-            run: pip install git+https://github.com/sphuber/aiida-core.git@feature/5495/storage-backend-entry-points
-
         -   name: Run pytest
             env:
                 AIIDA_S3_MOCK_AWS_S3: False

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
         -   name: Install Python package and dependencies
             run: pip install -e .[pre-commit,tests]
 
-        -   name: Install custom `aiida-core` branch
-            run: pip install git+https://github.com/sphuber/aiida-core.git@feature/5495/storage-backend-entry-points
-
         -   name: Run pre-commit
             run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
@@ -62,9 +59,6 @@ jobs:
 
         -   name: Install Python package and dependencies
             run: pip install -e .[tests]
-
-        -   name: Install custom `aiida-core` branch
-            run: pip install git+https://github.com/sphuber/aiida-core.git@feature/5495/storage-backend-entry-points
 
         -   name: Run pytest
             run: pytest -sv tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,4 +52,5 @@ repos:
         files: >-
             (?x)^(
                 src/.*py|
+                tests/.*py|
             )$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 keywords = ['aiida', 'workflows', 's3']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core~=2.0.0b1',
+    'aiida-core~=2.1',
+    'boto3',
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Source = 'https://github.com/sphuber/aiida-s3'
 
 [project.optional-dependencies]
 pre-commit = [
-    'mypy==0.941',
+    'mypy==0.981',
     'pre-commit~=2.17',
     'pylint~=2.12.2',
     'pylint-aiida~=0.1.1',
@@ -86,7 +86,9 @@ check_untyped_defs = true
 module = [
     'boto3.*',
     'botocore.*',
+    'moto.*',
     'pymatgen.*',
+    'pgtest.*',
     'ruamel.*',
 ]
 ignore_missing_imports = true

--- a/src/aiida_s3/py.typed
+++ b/src/aiida_s3/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/tests/repository/test_aws_s3.py
+++ b/tests/repository/test_aws_s3.py
@@ -2,6 +2,7 @@
 # pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_s3.repository.aws_s3` module."""
 import io
+import typing as t
 import uuid
 
 import pytest
@@ -10,14 +11,14 @@ from aiida_s3.repository.aws_s3 import AwsS3RepositoryBackend
 
 
 @pytest.fixture(scope='function')
-def repository_uninitialised(aws_s3_config) -> AwsS3RepositoryBackend:
+def repository_uninitialised(aws_s3_config) -> t.Generator[AwsS3RepositoryBackend, None, None]:
     """Return uninitialised instance of :class:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend`."""
     repository = AwsS3RepositoryBackend(str(uuid.uuid4()), **aws_s3_config)
     yield repository
 
 
 @pytest.fixture(scope='function')
-def repository(aws_s3_bucket_name, aws_s3_config) -> AwsS3RepositoryBackend:
+def repository(aws_s3_bucket_name, aws_s3_config) -> t.Generator[AwsS3RepositoryBackend, None, None]:
     """Return initialised instance of :class:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend`."""
     repository = AwsS3RepositoryBackend(aws_s3_bucket_name, **aws_s3_config)
     repository.initialise()

--- a/tests/storage/test_psql_aws_s3.py
+++ b/tests/storage/test_psql_aws_s3.py
@@ -10,10 +10,11 @@ from aiida_s3.repository.aws_s3 import AwsS3RepositoryBackend
 from aiida_s3.storage.psql_aws_s3 import PsqlAwsS3Storage
 
 
-@pytest.fixture
-def storage(aiida_profile):
+@pytest.fixture(scope='session')
+def storage(aiida_profile_factory, config_psql_aws_s3):
     """Return an instance of :class:`aiida_s3.repository.aws_s3.PsqlAwsS3Storage` configured for the test profile."""
-    return PsqlAwsS3Storage(profile=aiida_profile)
+    profile = aiida_profile_factory(config_psql_aws_s3())
+    yield PsqlAwsS3Storage(profile=profile)
 
 
 def test_get_repository(storage):
@@ -29,7 +30,7 @@ def test_node_storage():
     content = 'test content'
 
     node.base.attributes.set_many(attributes)
-    node.base.repository.put_object_from_filelike(io.StringIO(content), filename)
+    node.base.repository.put_object_from_filelike(io.StringIO(content), filename)  # type: ignore[arg-type]
     node.store()
 
     loaded = orm.load_node(node.pk)


### PR DESCRIPTION
The test fixtures that are improved by modularizing them. The
`aiida_profile_factory` fixture takes a dictionary that will be merged
into the default configuration. The `config_psql_dos` and
`config_psql_aws_s3` fixtures return a profile configuration dictionary
that can be used for the `core.psql_dos` and `s3.psql_aws_s3` storage
backend plugins. They each create the resources they require, such as a
PostgreSQL instance or an AWS S3 connection, or mock it when necessary.

The `aiida_profile` fixture is an easy shortcut which will automatically
call `aiida_profile_factory` with the config of `config_psql_dos`
providing a fully isolated and temporary AiiDA instance with a profile
configured with the `core.psql_dos` backend.