### PR TITLE
Add support for Azure Blob Storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,9 @@ disable = [
 filterwarnings = [
     'ignore:Creating AiiDA configuration folder.*:UserWarning'
 ]
+markers = [
+    'skip_if_azure_mocked: Skip if the Azure client is mocked, which is not supporte yet',
+]
 
 [tool.yapf]
 align_closing_bracket_with_visual_indent = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ keywords = ['aiida', 'workflows', 's3']
 requires-python = '>=3.8'
 dependencies = [
     'aiida-core @ git+https://github.com/aiidateam/aiida-core.git@main',
+    'azure-storage-blob',
     'boto3',
 ]
 
@@ -48,6 +49,7 @@ tests = [
 
 [project.entry-points.'aiida.storage']
 's3.psql_aws_s3' = 'aiida_s3.storage.psql_aws_s3:PsqlAwsS3Storage'
+'s3.psql_azure_blob' = 'aiida_s3.storage.psql_azure_blob:PsqlAzureBlobStorage'
 
 [tool.flit.module]
 name = 'aiida_s3'

--- a/src/aiida_s3/repository/azure_blob.py
+++ b/src/aiida_s3/repository/azure_blob.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""Implementation of the :py:`aiida.repository.backend.abstract.AbstractRepositoryBackend` using Azure Blob Storage."""
+from __future__ import annotations
+
+import contextlib
+import tempfile
+import typing as t
+import uuid
+
+from aiida.repository.backend.abstract import AbstractRepositoryBackend
+from azure.storage.blob import BlobServiceClient, ContainerClient
+
+__all__ = ('AzureBlobStorageRepositoryBackend',)
+
+
+class AzureBlobStorageRepositoryBackend(AbstractRepositoryBackend):
+    """Implementation of the ``AbstractRepositoryBackend`` using Azure Blob Storage as the backend."""
+
+    def __init__(self, container_name: str, connection_string: str):
+        """Construct a new instance for a given storage account and container.
+
+        .. note:: It is possible to construct an instance for a container that doesn't exist yet. To use the backend,
+            however, the container needs to exist. To ensure it exists, call ``initialise``, which will create the
+            container if it doesn't already.
+
+        :param container_name: The name of the container to use.
+        :param connection_string: The connection string for the Azure Blob Storage storage account.
+        """
+        self._container_name: str = container_name
+        self._connection_string: str = connection_string
+
+        try:
+            self._service_client: BlobServiceClient = BlobServiceClient.from_connection_string(self._connection_string)
+        except ValueError as exception:
+            raise ValueError(
+                f'could not connect with the given connection string: {self._connection_string}'
+            ) from exception
+
+        if self._service_client is None:
+            raise ValueError(f'failed to connect with the given connection string: {self._connection_string}')
+
+        self._container_client: ContainerClient = self._service_client.get_container_client(self._container_name)
+
+    def __str__(self) -> str:
+        """Return the string representation of this repository."""
+        return f'AwsS3RepositoryBackend: <{self._container_name}>'
+
+    @property
+    def _container_exists(self) -> bool:
+        """Return whether the container exists."""
+        return self._container_client.exists()
+
+    @property
+    def is_initialised(self) -> bool:
+        """Return whether the repository has been initialised.
+
+        This amounts to whether the configured container actually exists. Calling ``initialise`` will create the
+        container if it didn't already exist.
+        """
+        return self._container_exists
+
+    def initialise(self, **kwargs) -> None:
+        """Initialise the repository if it hasn't already been initialised.
+
+        :param kwargs: parameters for the initialisation.
+        """
+        if self.is_initialised:
+            return
+
+        self._container_client.create_container(**kwargs)
+
+    @property
+    def uuid(self) -> str:
+        """Return the unique identifier of the repository."""
+        return self._container_name
+
+    @property
+    def key_format(self) -> str:
+        """Return the format for the keys of the repository."""
+        return 'uuid4'
+
+    def erase(self):
+        """Delete the container configured for this instance and all its contents."""
+        if not self._container_exists:
+            return
+
+        self._container_client.delete_container()
+
+    def _put_object_from_filelike(self, handle: t.BinaryIO) -> str:
+        """Store the byte contents of a file in the repository.
+
+        :param handle: filelike object with the byte content to be stored.
+        :return: the generated fully qualified identifier for the object within the repository.
+        :raises TypeError: if the handle is not a byte stream.
+        """
+        key = str(uuid.uuid4())
+        self._container_client.upload_blob(name=key, data=handle)
+        return key
+
+    def has_objects(self, keys: list[str]) -> list[bool]:
+        """Return whether the repository has an object with the given key.
+
+        :param keys: list of fully qualified identifiers for objects within the repository.
+        :return: list of booleans, in the same order as the keys provided, with value True if the respective object
+            exists and False otherwise.
+        """
+        existing_keys = set(self.list_objects())
+        return [key in existing_keys for key in keys]
+
+    @contextlib.contextmanager
+    def open(self, key: str) -> t.Iterator[t.IO[bytes]]:  # type: ignore[override]
+        """Open a file handle to an object stored under the given key.
+
+        .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
+            ``put_object_from_filelike`` instead.
+
+        :param key: fully qualified identifier for the object within the repository.
+        :return: yield a byte stream object.
+        :raise FileNotFoundError: if the file does not exist.
+        :raise OSError: if the file could not be opened.
+        """
+        with tempfile.TemporaryFile(mode='w+b') as handle:
+            try:
+                self._container_client.download_blob(key).readinto(handle)
+            except Exception as exception:  # pylint: disable=broad-except
+                raise FileNotFoundError(f'object with key `{key}` does not exist.') from exception
+            handle.seek(0)
+            yield handle
+
+    def iter_object_streams(self, keys: list[str]) -> t.Iterator[tuple[str, t.IO[bytes]]]:  # type: ignore[override]
+        """Return an iterator over the (read-only) byte streams of objects identified by key.
+
+        .. note:: handles should only be read within the context of this iterator.
+
+        :param keys: fully qualified identifiers for the objects within the repository.
+        :return: an iterator over the object byte streams.
+        :raise FileNotFoundError: if the file does not exist.
+        :raise OSError: if a file could not be opened.
+        """
+        for key in keys:
+            with self.open(key) as handle:
+                yield key, handle
+
+    def delete_objects(self, keys: t.Iterable[str]) -> None:
+        """Delete the objects from the repository.
+
+        :param keys: list of fully qualified identifiers for the objects within the repository.
+        :raise FileNotFoundError: if any of the files does not exist.
+        :raise OSError: if any of the files could not be deleted.
+        """
+        super().delete_objects(list(keys))
+        if keys:
+            self._container_client.delete_blobs(*keys)
+
+    def list_objects(self) -> t.Iterable[str]:
+        """Return iterable that yields all available objects by key.
+
+        :return: An iterable for all the available object keys.
+        """
+        import traceback
+        traceback.print_stack()
+        for name in self._container_client.list_blob_names():
+            yield name
+
+    def maintain(  # type: ignore[override]
+        self,
+        dry_run: bool = False,
+        live: bool = True,
+        pack_loose: bool = None,
+        do_repack: bool = None,
+        clean_storage: bool = None,
+        do_vacuum: bool = None,
+    ) -> dict:
+        # pylint: disable=arguments-differ, unused-argument
+        """Perform maintenance operations.
+
+        :param live: if True, will only perform operations that are safe to do while the repository is in use.
+        :param pack_loose: flag for forcing the packing of loose files.
+        :param do_repack: flag for forcing the re-packing of already packed files.
+        :param clean_storage: flag for forcing the cleaning of soft-deleted files from the repository.
+        :param do_vacuum: flag for forcing the vacuuming of the internal database when cleaning the repository.
+        :return: a dictionary with information on the operations performed.
+        """
+        return {}
+
+    def get_info(  # type: ignore[override]
+        self,
+        detailed=False,
+    ) -> dict[str, int | str | dict[str, int] | dict[str, float]]:
+        # pylint: disable=arguments-differ, unused-argument
+        """Return information on configuration and content of the repository."""
+        return {}

--- a/src/aiida_s3/storage/psql_azure_blob.py
+++ b/src/aiida_s3/storage/psql_azure_blob.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + Azure."""
+from aiida.storage.psql_dos import PsqlDosBackend
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
+
+from ..repository.azure_blob import AzureBlobStorageRepositoryBackend
+
+
+class PsqlAzureBlobStorageMigrator(PsqlDosMigrator):
+    """Subclass :class:`aiida.storage.psql_dos.migrator.PsqlDosMigrator` to customize the repository implementation."""
+
+    def get_repository_uuid(self) -> str:
+        """Return the UUID of the repository.
+
+        :returns: The UUID of the repository of the configured profile.
+        """
+        return self.get_repository().uuid
+
+    def reset_repository(self) -> None:
+        """Reset the repository deleting the bucket and all its contents."""
+        repository = self.get_repository()
+        if repository.is_initialised:
+            repository.delete_objects(repository.list_objects())
+
+    def initialise_repository(self) -> None:
+        """Initialise the repository."""
+        repository = self.get_repository()
+        repository.initialise()
+
+    @property
+    def is_repository_initialised(self) -> bool:
+        """Return whether the repository is initialised.
+
+        :returns: Boolean, ``True`` if the repository is initalised, ``False`` otherwise.
+        """
+        return self.get_repository().is_initialised
+
+    def get_repository(self) -> AzureBlobStorageRepositoryBackend:
+        """Return the file repository backend instance.
+
+        :returns: The repository of the configured profile.
+        """
+        storage_config = self.profile.storage_config
+        container_name: str = storage_config['container_name']
+        connection_string: str = storage_config['connection_string']
+
+        return AzureBlobStorageRepositoryBackend(
+            container_name=container_name,
+            connection_string=connection_string,
+        )
+
+
+class PsqlAzureBlobStorage(PsqlDosBackend):
+    """Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + Azure."""
+
+    migrator = PsqlAzureBlobStorageMigrator
+
+    def get_repository(self) -> AzureBlobStorageRepositoryBackend:  # type: ignore[override]
+        """Return the file repository backend instance.
+
+        :returns: The repository of the configured profile.
+        """
+        return self.migrator(self.profile).get_repository()

--- a/tests/repository/test_azure_blob.py
+++ b/tests/repository/test_azure_blob.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Tests for the :mod:`aiida_s3.repository.azure_blob` module."""
+import io
+import typing as t
+import uuid
+
+import pytest
+
+from aiida_s3.repository.azure_blob import AzureBlobStorageRepositoryBackend
+
+
+@pytest.fixture(scope='function')
+def repository_uninitialised(azure_blob_config) -> t.Generator[AzureBlobStorageRepositoryBackend, None, None]:
+    """Return uninitialised instance of :class:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend`."""
+    repository = AzureBlobStorageRepositoryBackend(str(uuid.uuid4()), **azure_blob_config)
+    try:
+        yield repository
+    finally:
+        repository.erase()
+
+
+@pytest.fixture(scope='function')
+def repository(azure_blob_config) -> t.Generator[AzureBlobStorageRepositoryBackend, None, None]:
+    """Return initialised instance of :class:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend`."""
+    repository = AzureBlobStorageRepositoryBackend(str(uuid.uuid4()), **azure_blob_config)
+    repository.initialise()
+    try:
+        yield repository
+    finally:
+        repository.erase()
+
+
+def test_initialise(repository_uninitialised):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.initialise` method."""
+    repository = repository_uninitialised
+    assert not repository.is_initialised
+
+    # Initialise the repository, which means creating the bucket essentially.
+    repository.initialise()
+    assert repository.is_initialised
+
+    # Make sure to cleanup by deleting the created bucket.
+    repository.erase()
+
+
+def test_uuid(repository):
+    """Test the :prop:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.uuid` property."""
+    assert repository.uuid == repository._container_name  # pylint: disable=protected-access
+
+
+def test_key_format(repository):
+    """Test the :prop:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.key_format` property."""
+    assert repository.key_format == 'uuid4'
+
+
+def test_erase(repository, generate_directory):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.erase` method."""
+    directory = generate_directory({'file_a': None})
+
+    with open(directory / 'file_a', 'rb') as handle:
+        key = repository.put_object_from_filelike(handle)
+
+    assert repository.has_object(key)
+
+    repository.erase()
+
+    assert not repository.is_initialised
+
+
+def test_erase_uninitialised(repository_uninitialised):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.erase` method for uninited repo.
+
+    The method should not fail if the configure bucket does not exist.
+    """
+    assert repository_uninitialised.erase() is None
+
+
+def test_put_object_from_filelike_raises(repository, generate_directory):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.put_object_from_filelike`.
+
+    Test invocations for which the method should raise an exception.
+    """
+    directory = generate_directory({'file_a': None})
+
+    with pytest.raises(TypeError):
+        repository.put_object_from_filelike(directory / 'file_a')  # Path-like object
+
+    with pytest.raises(TypeError):
+        repository.put_object_from_filelike(directory / 'file_a')  # String
+
+    with pytest.raises(TypeError):
+        with open(directory / 'file_a', encoding='utf8') as handle:
+            repository.put_object_from_filelike(handle)  # Not in binary mode
+
+
+def test_put_object_from_filelike(repository, generate_directory):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.put_object_from_filelike` method."""
+    directory = generate_directory({'file_a': None})
+
+    with open(directory / 'file_a', 'rb') as handle:
+        key = repository.put_object_from_filelike(handle)
+
+    assert isinstance(key, str)
+
+
+def test_has_objects(repository, generate_directory):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.has_objects` method."""
+    directory = generate_directory({'file_a': None})
+
+    assert repository.has_objects(['non_existant']) == [False]
+
+    with open(directory / 'file_a', 'rb') as handle:
+        key = repository.put_object_from_filelike(handle)
+
+    assert repository.has_objects([key]) == [True]
+
+
+def test_open_raise(repository):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.open` method.
+
+    Test invocations for which the method should raise an exception.
+    """
+    with pytest.raises(FileNotFoundError):
+        with repository.open('non_existant'):
+            pass
+
+
+def test_open(repository, generate_directory):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.open` method."""
+    directory = generate_directory({'file_a': b'content_a', 'relative': {'file_b': b'content_b'}})
+
+    with open(directory / 'file_a', 'rb') as handle:
+        key_a = repository.put_object_from_filelike(handle)
+
+    with open(directory / 'relative/file_b', 'rb') as handle:
+        key_b = repository.put_object_from_filelike(handle)
+
+    with repository.open(key_a) as handle:
+        assert isinstance(handle, io.BufferedRandom)
+
+    with repository.open(key_a) as handle:
+        assert handle.read() == b'content_a'
+
+    with repository.open(key_b) as handle:
+        assert handle.read() == b'content_b'
+
+
+def test_iter_object_streams(repository):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.iter_object_streams` method."""
+    key = repository.put_object_from_filelike(io.BytesIO(b'content'))
+
+    for _key, stream in repository.iter_object_streams([key]):
+        assert _key == key
+        assert stream.read() == b'content'
+
+
+def test_delete_objects(repository, generate_directory):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.delete_objects` method."""
+    directory = generate_directory({'file_a': None})
+
+    with open(directory / 'file_a', 'rb') as handle:
+        key = repository.put_object_from_filelike(handle)
+
+    assert repository.has_object(key)
+
+    repository.delete_objects([key])
+    assert not repository.has_object(key)
+
+    # The call should not except when an empty list of keys is provided.
+    assert repository.delete_objects([]) is None
+
+
+def test_get_object_hash(repository, generate_directory):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.get_object_hash` method."""
+    directory = generate_directory({'file_a': b'content'})
+
+    with open(directory / 'file_a', 'rb') as handle:
+        key = repository.put_object_from_filelike(handle)
+
+    assert repository.get_object_hash(key) == 'ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73'
+
+
+def test_list_objects(repository, generate_directory):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.list_objects` method."""
+    keys = []
+
+    # First empty the repository because other tests may have added objects to it.
+    repository.delete_objects(repository.list_objects())
+    repository.initialise()
+
+    directory = generate_directory({'file_a': b'content a', 'file_b': b'content b'})
+
+    with open(directory / 'file_a', 'rb') as handle:
+        keys.append(repository.put_object_from_filelike(handle))
+
+    with open(directory / 'file_b', 'rb') as handle:
+        keys.append(repository.put_object_from_filelike(handle))
+
+    assert sorted(list(repository.list_objects())) == sorted(keys)
+
+
+def test_get_info(repository):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.get_info` method."""
+    assert repository.get_info() == {}
+
+
+def test_maintain(repository):
+    """Test :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.maintain` method."""
+    assert repository.maintain() == {}

--- a/tests/repository/test_azure_blob.py
+++ b/tests/repository/test_azure_blob.py
@@ -9,6 +9,8 @@ import pytest
 
 from aiida_s3.repository.azure_blob import AzureBlobStorageRepositoryBackend
 
+pytestmark = pytest.mark.skip_if_azure_mocked
+
 
 @pytest.fixture(scope='function')
 def repository_uninitialised(azure_blob_config) -> t.Generator[AzureBlobStorageRepositoryBackend, None, None]:

--- a/tests/storage/test_psql_azure_blob.py
+++ b/tests/storage/test_psql_azure_blob.py
@@ -9,6 +9,8 @@ import pytest
 from aiida_s3.repository.azure_blob import AzureBlobStorageRepositoryBackend
 from aiida_s3.storage.psql_azure_blob import PsqlAzureBlobStorage
 
+pytestmark = pytest.mark.skip_if_azure_mocked
+
 
 def test_get_repository(psql_azure_blob_profile):
     """Test the :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.get_repository` method."""

--- a/tests/storage/test_psql_azure_blob.py
+++ b/tests/storage/test_psql_azure_blob.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Tests for the :mod:`aiida_s3.storage.psql_azure_blob` module."""
+import io
+
+from aiida import orm
+import pytest
+
+from aiida_s3.repository.azure_blob import AzureBlobStorageRepositoryBackend
+from aiida_s3.storage.psql_azure_blob import PsqlAzureBlobStorage
+
+
+def test_get_repository(psql_azure_blob_profile):
+    """Test the :meth:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.get_repository` method."""
+    storage = PsqlAzureBlobStorage(psql_azure_blob_profile)
+    assert isinstance(storage.get_repository(), AzureBlobStorageRepositoryBackend)
+
+
+@pytest.mark.usefixtures('psql_azure_blob_profile')
+def test_node_storage():
+    """Test storing and loading a node with attributes and file objects."""
+    node = orm.Data()
+    attributes = {'a': 1, 'b': 'string'}
+    filename = 'file.txt'
+    content = 'test content'
+
+    node.base.attributes.set_many(attributes)
+    node.base.repository.put_object_from_filelike(io.StringIO(content), filename)  # type: ignore[arg-type]
+    node.store()
+
+    loaded = orm.load_node(node.pk)
+    assert loaded.base.attributes.all == attributes
+    assert loaded.base.repository.get_object_content(filename) == content


### PR DESCRIPTION
The `PsqlAzureBlobStorage` implementation of the storage backend is added with the `s3.psql_azure_blob` entry point. It allows to use a container on Azure Blob Storage as the file repository. The connection is setup using a connection string which can be obtained from the Azure portal for the Blob Storage service.