### PR TITLE
Add a command line interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ tests = [
     'pytest~=6.2',
 ]
 
+[project.scripts]
+aiida-s3 = "aiida_s3.cli:cmd_root"
+
 [project.entry-points.'aiida.storage']
 's3.psql_aws_s3' = 'aiida_s3.storage.psql_aws_s3:PsqlAwsS3Storage'
 's3.psql_azure_blob' = 'aiida_s3.storage.psql_azure_blob:PsqlAzureBlobStorage'

--- a/src/aiida_s3/cli/__init__.py
+++ b/src/aiida_s3/cli/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=wrong-import-position
+"""Command line interface for ``aiida-s3``."""
+from aiida.cmdline.groups.verdi import VerdiCommandGroup
+import click
+
+
+@click.group('aiida-s3', cls=VerdiCommandGroup)
+def cmd_root():
+    """Command line interface for ``aiida-s3``."""

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_s3.cli` module."""
+
+
+def test_help(run_cli_command):
+    """Test that command succeeds with the ``--help`` option."""
+    assert 'Usage:' in run_cli_command(['aiida-s3', '--help']).stdout


### PR DESCRIPTION
This will allow to implement an easy way for users to create a new profile with one of the storage backends provided by this plugin. The current state of `verdi` does not allow to easily implement this since the options of `verdi setup` are hardcoded for the `psql_dos` storage backend. If this plugin becomes successful, we can port the functionality of dynamically generated CLI commands to setup various storage backends to `aiida-core`.