### PR TITLE
CLI: Add the `profile setup` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ pre-commit = [
     'pre-commit~=2.17',
     'pylint~=2.12.2',
     'pylint-aiida~=0.1.1',
+    'types-pyyaml',
 ]
 tests = [
     'moto[s3]',

--- a/src/aiida_s3/cli/__init__.py
+++ b/src/aiida_s3/cli/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=wrong-import-position
+# pylint: disable=cyclic-import,wrong-import-position
 """Command line interface for ``aiida-s3``."""
 from aiida.cmdline.groups.verdi import VerdiCommandGroup
 import click
@@ -8,3 +8,6 @@ import click
 @click.group('aiida-s3', cls=VerdiCommandGroup)
 def cmd_root():
     """Command line interface for ``aiida-s3``."""
+
+
+from .cmd_profile import cmd_profile

--- a/src/aiida_s3/cli/cmd_profile.py
+++ b/src/aiida_s3/cli/cmd_profile.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""CLI commands to create profiles."""
+from aiida.cmdline.groups import DynamicEntryPointCommandGroup
+
+from . import cmd_root
+
+
+@cmd_root.group('profile')  # type: ignore[has-type]
+def cmd_profile():
+    """Commands to create profiles."""
+
+
+def create_profile(cls, non_interactive, **kwargs):  # pylint: disable=unused-argument
+    """Set up a new profile with an ``aiida-s3`` storage backend."""
+    import contextlib
+    import io
+
+    from aiida.cmdline.utils import echo
+    from aiida.manage.configuration import Profile, get_config
+
+    profile_name = kwargs.pop('profile_name')
+    profile_config = {
+        'storage': {
+            'backend': cls.get_entry_point().name,
+            'config': {
+                'database_engine': kwargs.pop('postgresql_engine'),
+                'database_hostname': kwargs.pop('postgresql_hostname'),
+                'database_port': kwargs.pop('postgresql_port'),
+                'database_username': kwargs.pop('postgresql_username'),
+                'database_password': kwargs.pop('postgresql_password'),
+                'database_name': kwargs.pop('postgresql_database_name'),
+            }
+        },
+        'process_control': {
+            'backend': 'rabbitmq',
+            'config': {
+                'broker_protocol': 'amqp',
+                'broker_username': 'guest',
+                'broker_password': 'guest',
+                'broker_host': '127.0.0.1',
+                'broker_port': 5672,
+                'broker_virtual_host': ''
+            }
+        },
+    }
+
+    profile_config['storage']['config'].update(**kwargs)
+    profile = Profile(profile_name, profile_config)
+
+    config = get_config()
+
+    if profile.name in config.profile_names:
+        echo.echo_critical(f'The profile `{profile.name}` already exists.')
+
+    config.add_profile(profile)
+
+    echo.echo_report('Initialising the storage backend.')
+    try:
+        with contextlib.redirect_stdout(io.StringIO()):
+            profile.storage_cls.initialise(profile)
+    except Exception as exception:  # pylint: disable=broad-except
+        echo.echo_critical(
+            f'Storage backend initialisation failed, probably because connection details are incorrect:\n{exception}'
+        )
+    else:
+        echo.echo_success('Storage backend initialisation completed.')
+
+    config.store()
+    echo.echo_success(f'Created new profile `{profile.name}`.')
+
+
+@cmd_profile.group(
+    'setup',
+    cls=DynamicEntryPointCommandGroup,
+    command=create_profile,
+    entry_point_group='aiida.storage',
+    entry_point_name_filter=r's3\..*'
+)
+def cmd_profile_setup():
+    """Set up a new profile with an ``aiida-s3`` storage backend."""

--- a/src/aiida_s3/storage/psql_aws_s3.py
+++ b/src/aiida_s3/storage/psql_aws_s3.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 """Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + AWS S3."""
-from aiida.storage.psql_dos import PsqlDosBackend
+from __future__ import annotations
+
+import typing as t
+
 from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 from ..repository.aws_s3 import AwsS3RepositoryBackend
+from .psql_dos import BasePsqlDosBackend
 
 
 class PsqlAwsS3StorageMigrator(PsqlDosMigrator):
@@ -54,8 +58,8 @@ class PsqlAwsS3StorageMigrator(PsqlDosMigrator):
         )
 
 
-class PsqlAwsS3Storage(PsqlDosBackend):
-    """Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + AWS S3."""
+class PsqlAwsS3Storage(BasePsqlDosBackend):
+    """Storage backend using PostgresSQL and AWS S3."""
 
     migrator = PsqlAwsS3StorageMigrator
 
@@ -65,3 +69,37 @@ class PsqlAwsS3Storage(PsqlDosBackend):
         :returns: The repository of the configured profile.
         """
         return self.migrator(self.profile).get_repository()
+
+    @classmethod
+    def _get_cli_options(cls) -> dict[str, t.Any]:
+        """Return the CLI options that would allow to create an instance of this class."""
+        options = super()._get_cli_options()
+        options.update(
+            **{
+                'aws_bucket_name': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'AWS bucket name',
+                    'help': 'The name of the AWS S3 bucket to use.',
+                },
+                'aws_access_key_id': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'AWS access key ID',
+                    'help': 'The AWS access key ID.',
+                },
+                'aws_secret_access_key': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'AWS secret access key',
+                    'help': 'The AWS secret access key.',
+                },
+                'aws_region_name': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'AWS region',
+                    'help': 'The AWS region name code, e.g., `eu-central-1`.',
+                }
+            }
+        )
+        return options

--- a/src/aiida_s3/storage/psql_azure_blob.py
+++ b/src/aiida_s3/storage/psql_azure_blob.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 """Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + Azure."""
-from aiida.storage.psql_dos import PsqlDosBackend
+from __future__ import annotations
+
+import typing as t
+
 from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 
 from ..repository.azure_blob import AzureBlobStorageRepositoryBackend
+from .psql_dos import BasePsqlDosBackend
 
 
 class PsqlAzureBlobStorageMigrator(PsqlDosMigrator):
@@ -50,8 +54,8 @@ class PsqlAzureBlobStorageMigrator(PsqlDosMigrator):
         )
 
 
-class PsqlAzureBlobStorage(PsqlDosBackend):
-    """Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + Azure."""
+class PsqlAzureBlobStorage(BasePsqlDosBackend):
+    """Storage backend using PostgresSQL and Azure Blob Storage."""
 
     migrator = PsqlAzureBlobStorageMigrator
 
@@ -61,3 +65,25 @@ class PsqlAzureBlobStorage(PsqlDosBackend):
         :returns: The repository of the configured profile.
         """
         return self.migrator(self.profile).get_repository()
+
+    @classmethod
+    def _get_cli_options(cls) -> dict[str, t.Any]:
+        """Return the CLI options that would allow to create an instance of this class."""
+        options = super()._get_cli_options()
+        options.update(
+            **{
+                'container_name': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'Container name',
+                    'help': 'The Azure Blob Storage container name.',
+                },
+                'connection_string': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'Connection string',
+                    'help': 'The Azure Blob Storage connection string.',
+                }
+            }
+        )
+        return options

--- a/src/aiida_s3/storage/psql_dos.py
+++ b/src/aiida_s3/storage/psql_dos.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + AWS S3."""
+from __future__ import annotations
+
+import collections
+
+from aiida.plugins.entry_point import EntryPoint
+from aiida.storage.psql_dos import PsqlDosBackend
+
+
+class BasePsqlDosBackend(PsqlDosBackend):
+    """Storage backend using PostgresSQL and AWS S3."""
+
+    @classmethod
+    def get_entry_point(cls) -> EntryPoint | None:
+        """Return the entry point with which this storage backend implementation is registered.
+
+        :return: The entry point or ``None`` if not found.
+        """
+        from aiida.plugins.entry_point import get_entry_point_from_class
+        return get_entry_point_from_class(cls.__module__, cls.__name__)[1]
+
+    @classmethod
+    def get_cli_options(cls) -> collections.OrderedDict:
+        """Return the CLI options that would allow to create an instance of this class."""
+        return collections.OrderedDict(cls._get_cli_options())
+
+    @classmethod
+    def _get_cli_options(cls) -> dict:
+        """Return the CLI options that would allow to create an instance of this class."""
+        return {
+            'profile_name': {
+                'required': True,
+                'type': str,
+                'prompt': 'Profile name',
+                'help': 'The name of the profile.',
+            },
+            'postgresql_engine': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql engine',
+                'default': 'postgresql_psycopg2',
+                'help': 'The engine to use to connect to the database.',
+            },
+            'postgresql_hostname': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql hostname',
+                'default': 'localhost',
+                'help': 'The hostname of the PostgreSQL server.',
+            },
+            'postgresql_port': {
+                'required': True,
+                'type': int,
+                'prompt': 'Postgresql port',
+                'default': '5432',
+                'help': 'The port of the PostgreSQL server.',
+            },
+            'postgresql_username': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql username',
+                'help': 'The username with which to connect to the PostgreSQL server.',
+            },
+            'postgresql_password': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql password',
+                'help': 'The password with which to connect to the PostgreSQL server.',
+            },
+            'postgresql_database_name': {
+                'required': True,
+                'type': str,
+                'prompt': 'Postgresql database name',
+                'help': 'The name of the database in the PostgreSQL server.',
+            }
+        }

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Tests for the :mod:`aiida_s3.cli.cmd_profile` module."""
+import pathlib
+
+from aiida.plugins import StorageFactory
+import pytest
+import yaml
+
+
+def filepath_config():
+    """Return an iterator over the files in the ``tests/static/config`` directory."""
+    for filepath in (pathlib.Path(__file__).parent.parent / 'static' / 'config').iterdir():
+        yield filepath
+
+
+@pytest.mark.parametrize('filepath_config', filepath_config())
+def test_setup(aiida_instance, run_cli_command, monkeypatch, filepath_config):
+    """Test the ``aiida-s3 profile setup`` command for all storage backends.
+
+    This will just verify that the command accepts the ``--config`` option with a valid YAML file containing the options
+    for the command and that it creates a new profile. The command normallyn also initialises the storage backend but
+    that usually requires credentials which are faked here and so the initialisation would fail. That is why the
+    :meth:`aiida.orm.implementation.storage_backend.StorageBackend.initialise` method is monkeypatched to be a no-op.
+    """
+    with filepath_config.open() as handle:
+        profile_config = yaml.safe_load(handle)
+
+    entry_point = f's3.{filepath_config.stem}'
+    cls = StorageFactory(entry_point)
+    profile_name = profile_config['profile_name']
+
+    monkeypatch.setattr(cls, 'initialise', lambda *args: True)
+
+    # Must set ``use_subprocess=False`` because the ``initialise`` method of the storage implementation needs to be
+    # monkeypatched, because it will fail since the credentials for the services are fake.
+    result = run_cli_command(['profile', 'setup', entry_point, '--config', str(filepath_config)], use_subprocess=False)
+    assert f'Success: Created new profile `{profile_name}`.' in result.output_lines
+    assert profile_name in aiida_instance.profile_names

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -4,4 +4,4 @@
 
 def test_help(run_cli_command):
     """Test that command succeeds with the ``--help`` option."""
-    assert 'Usage:' in run_cli_command(['aiida-s3', '--help']).stdout
+    assert 'Usage:' in run_cli_command(['--help']).stdout

--- a/tests/static/config/psql_aws_s3.yml
+++ b/tests/static/config/psql_aws_s3.yml
@@ -1,0 +1,12 @@
+---
+profile_name: 'psql-aws-s3'
+postgresql_engine: 'postgresql_psycopg2'
+postgresql_hostname : 'localhost'
+postgresql_port : 5432
+postgresql_username: 'aiida'
+postgresql_password : 'password'
+postgresql_database_name: 'aiida_psql_aws_s3'
+aws_bucket_name : 'aiida-s3-bucket'
+aws_access_key_id: 'access-key-id'
+aws_secret_access_key: 'secret-access-key'
+aws_region_name: 'eu-central-1'

--- a/tests/static/config/psql_azure_blob.yml
+++ b/tests/static/config/psql_azure_blob.yml
@@ -1,0 +1,10 @@
+---
+profile_name: 'psql-azure-blob'
+postgresql_engine: 'postgresql_psycopg2'
+postgresql_hostname : 'localhost'
+postgresql_port : 5432
+postgresql_username: 'aiida'
+postgresql_password : 'password'
+postgresql_database_name: 'aiida_psql_azure_blob'
+container_name : 'aiida-s3-container'
+connection_string: 'connection-string'


### PR DESCRIPTION
This command automatically generates a subcommand for each registered entry point in the `aiida.storage` group that starts with `s3.`, i.e., all storage backend implemenations provided by `aiida-s3`.

Each command is dynamically built by loading the class corresponding to the entry point and getting the option specifications by calling the `get_cli_options` class method. Each implementation adds the options that are required to fully define the storage configuration in the profile which allows to instantiate an instance of the storage backend.

The current plugins, `PsqlAwsS3` and `PsqlAzureBlob` both extend the `PsqlDosBackend` that ships with `aiida-core` and simply replace the repository. Each of them therefore requires the configuration of the PostgreSQL database. The options for the storage backends in the profile setup command in `aiida-core` are not yet dynamically generated but the command line options are hardcoded. To provide them here, the `PsqlDosBackend` is subclassed as `BasePsqlDosBackend` such that it can provide the CLI options necessary to configure PostgreSQL. The storage backend subclasses can then add their options to connect to AWS S3 or Azure Blob Storage, respectively.