### PR TITLE
Add the `S3RepositoryBackend` base class

### DIFF
--- a/.github/workflows/aws-s3.yml
+++ b/.github/workflows/aws-s3.yml
@@ -38,7 +38,7 @@ jobs:
         -   name: Run pytest
             env:
                 AIIDA_S3_MOCK_AWS_S3: False
-                AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                AWS_REGION_NAME: ${{ github.event.inputs.region_name }}
+                AIIDA_S3_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                AIIDA_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                AIIDA_S3_AWS_REGION_NAME: ${{ github.event.inputs.region_name }}
             run: pytest -sv tests

--- a/.github/workflows/azure-blob.yml
+++ b/.github/workflows/azure-blob.yml
@@ -38,6 +38,6 @@ jobs:
         -   name: Run pytest
             env:
                 AIIDA_S3_MOCK_AZURE_BLOB: False
-                AZURE_BLOB_CONNECTION_STRING: ${{ secrets.AZURE_BLOB_CONNECTION_STRING }}
-                AZURE_BLOB_CONTAINER_NAME: ${{ github.event.inputs.container_name }}
+                AIIDA_S3_AZURE_BLOB_CONNECTION_STRING: ${{ secrets.AZURE_BLOB_CONNECTION_STRING }}
+                AIIDA_S3_AZURE_BLOB_CONTAINER_NAME: ${{ github.event.inputs.container_name }}
             run: pytest -sv tests

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,6 +62,17 @@ jobs:
             matrix:
                 python-version: ['3.8', '3.9', '3.10', '3.11']
 
+        services:
+            minio:
+                image: minio/minio:edge-cicd
+                volumes:
+                -   /data
+                ports:
+                -   9000:9000
+                env:
+                    MINIO_ACCESS_KEY: minio-access-key
+                    MINIO_SECRET_KEY: minio-secret-key
+
         steps:
         -   uses: actions/checkout@v2
 
@@ -83,6 +94,12 @@ jobs:
             run: pip install -e .[tests]
 
         -   name: Run pytest
+            env:
+                AIIDA_S3_MOCK_S3: false
+                AIIDA_S3_BUCKET_NAME: minio-bucket
+                AIIDA_S3_ENDPOINT_URL: http://localhost:9000
+                AIIDA_S3_ACCESS_KEY_ID: minio-access-key
+                AIIDA_S3_SECRET_ACCESS_KEY: minio-secret-key
             run: pytest -sv tests
 
     publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,17 @@ jobs:
             matrix:
                 python-version: ['3.8', '3.9', '3.10', '3.11']
 
+        services:
+            minio:
+                image: minio/minio:edge-cicd
+                volumes:
+                -   /data
+                ports:
+                -   9000:9000
+                env:
+                    MINIO_ACCESS_KEY: minio-access-key
+                    MINIO_SECRET_KEY: minio-secret-key
+
         steps:
         -   uses: actions/checkout@v2
 
@@ -61,4 +72,10 @@ jobs:
             run: pip install -e .[tests]
 
         -   name: Run pytest
+            env:
+                AIIDA_S3_MOCK_S3: false
+                AIIDA_S3_BUCKET_NAME: minio-bucket
+                AIIDA_S3_ENDPOINT_URL: http://localhost:9000
+                AIIDA_S3_ACCESS_KEY_ID: minio-access-key
+                AIIDA_S3_SECRET_ACCESS_KEY: minio-secret-key
             run: pytest -sv tests

--- a/README.md
+++ b/README.md
@@ -58,6 +58,53 @@ The plugin provides interfaces to various services that require credentials, suc
 To run the test suite, one has to provide these credentials or the services have to be mocked.
 Instructions for each service that is supported are provided below.
 
+### S3
+
+The base S3 implementation is interfaced with through the [`boto3`](https://pypi.org/project/boto3/) Python SDK.
+The [`moto`](https://pypi.org/project/moto/) library allows to mock this interface.
+This makes it possible to run the test suite without any credentials.
+To run the tests, simply execute `pytest`:
+
+    pytest
+
+By default, the interactions with S3 are mocked through `moto` and no actual credentials are required.
+To run the tests against an actual S3 server, the endpoint URL and credentials need to be specified through environment variables:
+
+    export AIIDA_S3_MOCK_S3=False
+    export AIIDA_S3_ENDPOINT_URL='http://localhost:9000'
+    export AIIDA_S3_BUCKET_NAME='some-bucket'
+    export AIIDA_S3_ACCESS_KEY_ID='access-key'
+    export AIIDA_S3_SECRET_ACCESS_KEY='secret-access-key'
+    pytest
+
+One example of an open source implementation of a S3-compatible object store is [minIO](https://min.io/).
+An instance can easily be created locally using Docker and `docker-compose`.
+Simply write the following to `docker-compose.yml`:
+
+    version: '2'
+
+    services:
+      minio:
+        container_name: Minio
+        command: server /data --console-address ":9001"
+        environment:
+          - MINIO_ROOT_USER=admin
+          - MINIO_ROOT_PASSWORD=supersecret
+        image: quay.io/minio/minio:latest
+        ports:
+          - '9000:9000'
+          - '9001:9001'
+        volumes:
+          - /tmp/minio:/data
+        restart: unless-stopped
+
+and then launch the container with:
+
+    docker-compose up -d
+
+The tests can then be run against the server using environment variables as described above.
+
+
 ### AWS S3
 
 The [AWS S3](https://aws.amazon.com/s3/) service is interfaced with through the [`boto3`](https://pypi.org/project/boto3/) Python SDK.
@@ -71,9 +118,9 @@ By default, the interactions with AWS S3 are mocked through `moto` and no actual
 To run the tests against an actual AWS S3 container, the credentials need to be specified through environment variables:
 
     export AIIDA_S3_MOCK_AWS_S3=False
-    export AWS_BUCKET_NAME='some-bucket'
-    export AWS_ACCESS_KEY_ID='access-key'
-    export AWS_SECRET_ACCESS_KEY='secret-access-key'
+    export AIIDA_S3_AWS_BUCKET_NAME='some-bucket'
+    export AIIDA_S3_AWS_ACCESS_KEY_ID='access-key'
+    export AIIDA_S3_AWS_SECRET_ACCESS_KEY='secret-access-key'
     pytest
 
 
@@ -85,8 +132,8 @@ Therefore, when the tests are run without credentials, and so the Azure Blob Sto
 To run the tests against an actual AWS S3 container, the credentials need to be specified through environment variables:
 
     export AIIDA_S3_MOCK_AZURE_BLOB=False
-    export AZURE_BLOB_CONTAINER_NAME='some-container'
-    export AZURE_BLOB_CONNECTION_STRING='DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net'
+    export AIIDA_S3_AZURE_BLOB_CONTAINER_NAME='some-container'
+    export AIIDA_S3_AZURE_BLOB_CONNECTION_STRING='DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net'
     pytest
 
 The specified container does not have to exist yet, it will be created automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,14 @@ pre-commit = [
 tests = [
     'moto[s3]',
     'pgtest~=1.3,>=1.3.1',
-    'pytest~=6.2',
+    'pytest~=7.2',
 ]
 
 [project.scripts]
 aiida-s3 = "aiida_s3.cli:cmd_root"
 
 [project.entry-points.'aiida.storage']
+'s3.psql_s3' = 'aiida_s3.storage.psql_s3:PsqlS3Storage'
 's3.psql_aws_s3' = 'aiida_s3.storage.psql_aws_s3:PsqlAwsS3Storage'
 's3.psql_azure_blob' = 'aiida_s3.storage.psql_azure_blob:PsqlAzureBlobStorage'
 
@@ -106,6 +107,11 @@ ignore = [
     'D104',
     'D203',
     'D213'
+]
+
+[tool.pylint.basic]
+good-names = [
+    's3',
 ]
 
 [tool.pylint.master]

--- a/src/aiida_s3/__init__.py
+++ b/src/aiida_s3/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-"""AiiDA plugin that provides a storage backend using AWS S3 for the file repository."""
+"""AiiDA plugin that provides a storage backend using an S3 object store as the file repository."""
 __version__ = '0.1.0'

--- a/src/aiida_s3/repository/aws_s3.py
+++ b/src/aiida_s3/repository/aws_s3.py
@@ -2,33 +2,29 @@
 """Implementation of the :py:`aiida.repository.backend.abstract.AbstractRepositoryBackend` using AWS S3 as backend."""
 from __future__ import annotations
 
-import contextlib
-import tempfile
-import typing as t
-import uuid
-
-from aiida.repository.backend.abstract import AbstractRepositoryBackend
 import boto3
-import botocore
+
+from .s3 import S3RepositoryBackend
 
 __all__ = ('AwsS3RepositoryBackend',)
 
 
-class AwsS3RepositoryBackend(AbstractRepositoryBackend):
+class AwsS3RepositoryBackend(S3RepositoryBackend):
     """Implementation of the ``AbstractRepositoryBackend`` using S3 as the backend."""
 
-    def __init__(self, bucket_name: str, aws_access_key_id: str, aws_secret_access_key: str, region_name: str):
+    def __init__(self, aws_access_key_id: str, aws_secret_access_key: str, region_name: str, bucket_name: str):
         """Construct a new instance for a given bucket.
 
         .. note:: It is possible to construct an instance for a bucket that doesn't exist yet. To use the backend,
             however, the bucket needs to exist. To ensure it exists, call ``initialise``, which will create the bucket
             if it doesn't already.
 
-        :param bucket_name: The name of the bucket to use.
         :param aws_access_key_id: The AWS access key ID to use to authenticate with AWS S3.
         :param aws_secret_access_key: The AWS secret access key to use to authenticate with AWS S3.
         :param region_name: The AWS region name to create the bucket in if it doesn't yet exist.
+        :param bucket_name: The name of the bucket to use.
         """
+        # pylint: disable=super-init-not-called
         self._bucket_name = bucket_name
         self._region_name = region_name
         self._client = boto3.client(
@@ -42,160 +38,12 @@ class AwsS3RepositoryBackend(AbstractRepositoryBackend):
         """Return the string representation of this repository."""
         return f'AwsS3RepositoryBackend: <{self._bucket_name}>'
 
-    @property
-    def _bucket_exists(self) -> bool:
-        """Return whether the bucket exists."""
-        try:
-            self._client.head_bucket(Bucket=self._bucket_name)
-        except botocore.exceptions.ClientError:
-            return False
-
-        return True
-
-    @property
-    def is_initialised(self) -> bool:
-        """Return whether the repository has been initialised.
-
-        This amounts to whether the configured bucket actually exists. Calling ``initialise`` will create the bucket
-        if it didn't already exist.
-        """
-        return self._bucket_exists
-
     def initialise(self, **kwargs) -> None:
         """Initialise the repository if it hasn't already been initialised.
 
         :param kwargs: parameters for the initialisation.
         """
-        if self.is_initialised:
-            return
-
         if self._region_name is not None:
-            kwargs = {'CreateBucketConfiguration': {'LocationConstraint': self._region_name}}
-        else:
-            kwargs = {}
+            kwargs['CreateBucketConfiguration'] = {'LocationConstraint': self._region_name}
 
-        self._client.create_bucket(Bucket=self._bucket_name, **kwargs)
-
-    @property
-    def uuid(self) -> str:
-        """Return the unique identifier of the repository."""
-        return self._bucket_name
-
-    @property
-    def key_format(self) -> str | None:
-        """Return the format for the keys of the repository."""
-        return 'uuid4'
-
-    def erase(self):
-        """Delete the bucket configured for this instance and all its contents."""
-        if not self._bucket_exists:
-            return
-
-        self.delete_objects(list(self.list_objects()))
-        self._client.delete_bucket(Bucket=self._bucket_name)
-
-    def _put_object_from_filelike(self, handle: t.BinaryIO) -> str:
-        """Store the byte contents of a file in the repository.
-
-        :param handle: filelike object with the byte content to be stored.
-        :return: the generated fully qualified identifier for the object within the repository.
-        :raises TypeError: if the handle is not a byte stream.
-        """
-        key = str(uuid.uuid4())
-        self._client.put_object(Bucket=self._bucket_name, Body=handle, Key=key)
-        return key
-
-    def has_objects(self, keys: list[str]) -> list[bool]:
-        """Return whether the repository has an object with the given key.
-
-        :param keys: list of fully qualified identifiers for objects within the repository.
-        :return: list of booleans, in the same order as the keys provided, with value True if the respective object
-            exists and False otherwise.
-        """
-        existing_keys = set(self.list_objects())
-        return [key in existing_keys for key in keys]
-
-    @contextlib.contextmanager
-    def open(self, key: str) -> t.Iterator[t.IO[bytes]]:  # type: ignore[override]
-        """Open a file handle to an object stored under the given key.
-
-        .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
-            ``put_object_from_filelike`` instead.
-
-        :param key: fully qualified identifier for the object within the repository.
-        :return: yield a byte stream object.
-        :raise FileNotFoundError: if the file does not exist.
-        :raise OSError: if the file could not be opened.
-        """
-        super().open(key)
-        with tempfile.TemporaryFile() as handle:
-            self._client.download_fileobj(self._bucket_name, key, handle)
-            handle.seek(0)
-            yield handle
-
-    def iter_object_streams(self, keys: list[str]) -> t.Iterator[tuple[str, t.IO[bytes]]]:  # type: ignore[override]
-        """Return an iterator over the (read-only) byte streams of objects identified by key.
-
-        .. note:: handles should only be read within the context of this iterator.
-
-        :param keys: fully qualified identifiers for the objects within the repository.
-        :return: an iterator over the object byte streams.
-        :raise FileNotFoundError: if the file does not exist.
-        :raise OSError: if a file could not be opened.
-        """
-        for key in keys:
-            with self.open(key) as handle:
-                yield key, handle
-
-    def delete_objects(self, keys: list[str]) -> None:
-        """Delete the objects from the repository.
-
-        :param keys: list of fully qualified identifiers for the objects within the repository.
-        :raise FileNotFoundError: if any of the files does not exist.
-        :raise OSError: if any of the files could not be deleted.
-        """
-        super().delete_objects(keys)
-        if keys:
-            self._client.delete_objects(Bucket=self._bucket_name, Delete={'Objects': [{'Key': key} for key in keys]})
-
-    def list_objects(self) -> t.Iterable[str]:
-        """Return iterable that yields all available objects by key.
-
-        :return: An iterable for all the available object keys.
-        """
-        response = self._client.list_objects(Bucket=self._bucket_name)
-
-        if 'Contents' not in response:
-            yield from ()
-        else:
-            for obj in self._client.list_objects(Bucket=self._bucket_name)['Contents']:
-                yield obj['Key']
-
-    def maintain(  # type: ignore[override]
-        self,
-        dry_run: bool = False,
-        live: bool = True,
-        pack_loose: bool = None,
-        do_repack: bool = None,
-        clean_storage: bool = None,
-        do_vacuum: bool = None,
-    ) -> dict:
-        # pylint: disable=arguments-differ, unused-argument
-        """Perform maintenance operations.
-
-        :param live: if True, will only perform operations that are safe to do while the repository is in use.
-        :param pack_loose: flag for forcing the packing of loose files.
-        :param do_repack: flag for forcing the re-packing of already packed files.
-        :param clean_storage: flag for forcing the cleaning of soft-deleted files from the repository.
-        :param do_vacuum: flag for forcing the vacuuming of the internal database when cleaning the repository.
-        :return: a dictionary with information on the operations performed.
-        """
-        return {}
-
-    def get_info(  # type: ignore[override]
-        self,
-        detailed=False,
-    ) -> dict[str, int | str | dict[str, int] | dict[str, float]]:
-        # pylint: disable=arguments-differ, unused-argument
-        """Return information on configuration and content of the repository."""
-        return {}
+        super().initialise(**kwargs)

--- a/src/aiida_s3/repository/s3.py
+++ b/src/aiida_s3/repository/s3.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""Implementation of the :py:`aiida.repository.backend.abstract.AbstractRepositoryBackend` using S3 as backend."""
+from __future__ import annotations
+
+import contextlib
+import tempfile
+import typing as t
+import uuid
+
+from aiida.repository.backend.abstract import AbstractRepositoryBackend
+import boto3
+import botocore
+
+__all__ = ('S3RepositoryBackend',)
+
+
+class S3RepositoryBackend(AbstractRepositoryBackend):
+    """Implementation of the ``AbstractRepositoryBackend`` using S3 as the backend."""
+
+    def __init__(self, endpoint_url: str, access_key_id: str, secret_access_key: str, bucket_name: str):
+        """Construct a new instance for a given bucket.
+
+        .. note:: It is possible to construct an instance for a bucket that doesn't exist yet. To use the backend,
+            however, the bucket needs to exist. To ensure it exists, call ``initialise``, which will create the bucket
+            if it doesn't already.
+
+        :param endpoint_url: The endpoint URL of the server to connect to.
+        :param access_key_id: The access key ID to use to authenticate with S3.
+        :param secret_access_key: The secret access key to use to authenticate with S3.
+        :param bucket_name: The name of the bucket to use.
+        """
+        self._bucket_name = bucket_name
+        self._client = boto3.client(
+            's3',
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
+
+    def __str__(self) -> str:
+        """Return the string representation of this repository."""
+        return f'S3RepositoryBackend: <{self._bucket_name}>'
+
+    @property
+    def _bucket_exists(self) -> bool:
+        """Return whether the bucket exists."""
+        try:
+            self._client.head_bucket(Bucket=self._bucket_name)
+        except botocore.exceptions.ClientError:
+            return False
+
+        return True
+
+    @property
+    def is_initialised(self) -> bool:
+        """Return whether the repository has been initialised.
+
+        This amounts to whether the configured bucket actually exists. Calling ``initialise`` will create the bucket
+        if it didn't already exist.
+        """
+        return self._bucket_exists
+
+    def initialise(self, **kwargs) -> None:
+        """Initialise the repository if it hasn't already been initialised.
+
+        :param kwargs: parameters for the initialisation.
+        """
+        if self.is_initialised:
+            return
+
+        self._client.create_bucket(Bucket=self._bucket_name, **kwargs)
+
+    @property
+    def uuid(self) -> str:
+        """Return the unique identifier of the repository."""
+        return self._bucket_name
+
+    @property
+    def key_format(self) -> str | None:
+        """Return the format for the keys of the repository."""
+        return 'uuid4'
+
+    def erase(self):
+        """Delete the bucket configured for this instance and all its contents."""
+        if not self._bucket_exists:
+            return
+
+        self.delete_objects(list(self.list_objects()))
+        self._client.delete_bucket(Bucket=self._bucket_name)
+
+    def _put_object_from_filelike(self, handle: t.BinaryIO) -> str:
+        """Store the byte contents of a file in the repository.
+
+        :param handle: filelike object with the byte content to be stored.
+        :return: the generated fully qualified identifier for the object within the repository.
+        :raises TypeError: if the handle is not a byte stream.
+        """
+        key = str(uuid.uuid4())
+        self._client.put_object(Bucket=self._bucket_name, Body=handle, Key=key)
+        return key
+
+    def has_objects(self, keys: list[str]) -> list[bool]:
+        """Return whether the repository has an object with the given key.
+
+        :param keys: list of fully qualified identifiers for objects within the repository.
+        :return: list of booleans, in the same order as the keys provided, with value True if the respective object
+            exists and False otherwise.
+        """
+        existing_keys = set(self.list_objects())
+        return [key in existing_keys for key in keys]
+
+    @contextlib.contextmanager
+    def open(self, key: str) -> t.Iterator[t.IO[bytes]]:  # type: ignore[override]
+        """Open a file handle to an object stored under the given key.
+
+        .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
+            ``put_object_from_filelike`` instead.
+
+        :param key: fully qualified identifier for the object within the repository.
+        :return: yield a byte stream object.
+        :raise FileNotFoundError: if the file does not exist.
+        :raise OSError: if the file could not be opened.
+        """
+        super().open(key)
+        with tempfile.TemporaryFile() as handle:
+            self._client.download_fileobj(self._bucket_name, key, handle)
+            handle.seek(0)
+            yield handle
+
+    def iter_object_streams(self, keys: list[str]) -> t.Iterator[tuple[str, t.IO[bytes]]]:  # type: ignore[override]
+        """Return an iterator over the (read-only) byte streams of objects identified by key.
+
+        .. note:: handles should only be read within the context of this iterator.
+
+        :param keys: fully qualified identifiers for the objects within the repository.
+        :return: an iterator over the object byte streams.
+        :raise FileNotFoundError: if the file does not exist.
+        :raise OSError: if a file could not be opened.
+        """
+        for key in keys:
+            with self.open(key) as handle:
+                yield key, handle
+
+    def delete_objects(self, keys: list[str]) -> None:
+        """Delete the objects from the repository.
+
+        :param keys: list of fully qualified identifiers for the objects within the repository.
+        :raise FileNotFoundError: if any of the files does not exist.
+        :raise OSError: if any of the files could not be deleted.
+        """
+        super().delete_objects(keys)
+        if keys:
+            self._client.delete_objects(Bucket=self._bucket_name, Delete={'Objects': [{'Key': key} for key in keys]})
+
+    def list_objects(self) -> t.Iterable[str]:
+        """Return iterable that yields all available objects by key.
+
+        :return: An iterable for all the available object keys.
+        """
+        response = self._client.list_objects(Bucket=self._bucket_name)
+
+        if 'Contents' not in response:
+            yield from ()
+        else:
+            for obj in self._client.list_objects(Bucket=self._bucket_name)['Contents']:
+                yield obj['Key']
+
+    def maintain(  # type: ignore[override]
+        self,
+        dry_run: bool = False,
+        live: bool = True,
+        pack_loose: bool = None,
+        do_repack: bool = None,
+        clean_storage: bool = None,
+        do_vacuum: bool = None,
+    ) -> dict:
+        # pylint: disable=arguments-differ, unused-argument
+        """Perform maintenance operations.
+
+        :param live: if True, will only perform operations that are safe to do while the repository is in use.
+        :param pack_loose: flag for forcing the packing of loose files.
+        :param do_repack: flag for forcing the re-packing of already packed files.
+        :param clean_storage: flag for forcing the cleaning of soft-deleted files from the repository.
+        :param do_vacuum: flag for forcing the vacuuming of the internal database when cleaning the repository.
+        :return: a dictionary with information on the operations performed.
+        """
+        return {}
+
+    def get_info(  # type: ignore[override]
+        self,
+        detailed=False,
+    ) -> dict[str, int | str | dict[str, int] | dict[str, float]]:
+        # pylint: disable=arguments-differ, unused-argument
+        """Return information on configuration and content of the repository."""
+        return {}

--- a/src/aiida_s3/storage/psql_azure_blob.py
+++ b/src/aiida_s3/storage/psql_azure_blob.py
@@ -4,21 +4,13 @@ from __future__ import annotations
 
 import typing as t
 
-from aiida.storage.psql_dos.migrator import PsqlDosMigrator
-
 from ..repository.azure_blob import AzureBlobStorageRepositoryBackend
 from .psql_dos import BasePsqlDosBackend
+from .psql_s3 import PsqlS3StorageMigrator
 
 
-class PsqlAzureBlobStorageMigrator(PsqlDosMigrator):
+class PsqlAzureBlobStorageMigrator(PsqlS3StorageMigrator):
     """Subclass :class:`aiida.storage.psql_dos.migrator.PsqlDosMigrator` to customize the repository implementation."""
-
-    def get_repository_uuid(self) -> str:
-        """Return the UUID of the repository.
-
-        :returns: The UUID of the repository of the configured profile.
-        """
-        return self.get_repository().uuid
 
     def reset_repository(self) -> None:
         """Reset the repository deleting the bucket and all its contents."""
@@ -26,31 +18,16 @@ class PsqlAzureBlobStorageMigrator(PsqlDosMigrator):
         if repository.is_initialised:
             repository.delete_objects(repository.list_objects())
 
-    def initialise_repository(self) -> None:
-        """Initialise the repository."""
-        repository = self.get_repository()
-        repository.initialise()
-
-    @property
-    def is_repository_initialised(self) -> bool:
-        """Return whether the repository is initialised.
-
-        :returns: Boolean, ``True`` if the repository is initalised, ``False`` otherwise.
-        """
-        return self.get_repository().is_initialised
-
-    def get_repository(self) -> AzureBlobStorageRepositoryBackend:
+    def get_repository(self) -> AzureBlobStorageRepositoryBackend:  # type: ignore[override]
         """Return the file repository backend instance.
 
         :returns: The repository of the configured profile.
         """
         storage_config = self.profile.storage_config
-        container_name: str = storage_config['container_name']
-        connection_string: str = storage_config['connection_string']
 
         return AzureBlobStorageRepositoryBackend(
-            container_name=container_name,
-            connection_string=connection_string,
+            container_name=storage_config['container_name'],
+            connection_string=storage_config['connection_string'],
         )
 
 

--- a/src/aiida_s3/storage/psql_s3.py
+++ b/src/aiida_s3/storage/psql_s3.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + S3."""
+from __future__ import annotations
+
+import typing as t
+
+from aiida.storage.psql_dos.migrator import PsqlDosMigrator
+
+from ..repository.s3 import S3RepositoryBackend
+from .psql_dos import BasePsqlDosBackend
+
+
+class PsqlS3StorageMigrator(PsqlDosMigrator):
+    """Subclass :class:`aiida.storage.psql_dos.migrator.PsqlDosMigrator` to customize the repository implementation."""
+
+    def get_repository_uuid(self) -> str:
+        """Return the UUID of the repository.
+
+        :returns: The UUID of the repository of the configured profile.
+        """
+        return self.get_repository().uuid
+
+    def reset_repository(self) -> None:
+        """Reset the repository deleting the bucket and all its contents."""
+        repository = self.get_repository()
+        if repository.is_initialised:
+            repository.erase()
+
+    def initialise_repository(self) -> None:
+        """Initialise the repository."""
+        repository = self.get_repository()
+        repository.initialise()
+
+    @property
+    def is_repository_initialised(self) -> bool:
+        """Return whether the repository is initialised.
+
+        :returns: Boolean, ``True`` if the repository is initalised, ``False`` otherwise.
+        """
+        return self.get_repository().is_initialised
+
+    def get_repository(self) -> S3RepositoryBackend:
+        """Return the file repository backend instance.
+
+        :returns: The repository of the configured profile.
+        """
+        storage_config = self.profile.storage_config
+
+        return S3RepositoryBackend(
+            endpoint_url=storage_config['endpoint_url'],
+            access_key_id=storage_config['access_key_id'],
+            secret_access_key=storage_config['secret_access_key'],
+            bucket_name=storage_config['bucket_name'],
+        )
+
+
+class PsqlS3Storage(BasePsqlDosBackend):
+    """Storage backend using PostgresSQL and S3 object store."""
+
+    migrator = PsqlS3StorageMigrator
+
+    def get_repository(self) -> S3RepositoryBackend:  # type: ignore[override]
+        """Return the file repository backend instance.
+
+        :returns: The repository of the configured profile.
+        """
+        return self.migrator(self.profile).get_repository()
+
+    @classmethod
+    def _get_cli_options(cls) -> dict[str, t.Any]:
+        """Return the CLI options that would allow to create an instance of this class."""
+        options = super()._get_cli_options()
+        options.update(
+            **{
+                'endpoint_url': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'Server endpoint URL',
+                    'help': 'The endpoint URL of the server to connect to.',
+                },
+                'access_key_id': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'Access key ID',
+                    'help': 'The access key ID.',
+                },
+                'secret_access_key': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'Secret access key',
+                    'help': 'The secret access key.',
+                },
+                'bucket_name': {
+                    'required': True,
+                    'type': str,
+                    'prompt': 'Bucket name',
+                    'help': 'The name of the S3 bucket to use.',
+                },
+            }
+        )
+        return options

--- a/tests/repository/test_s3.py
+++ b/tests/repository/test_s3.py
@@ -1,32 +1,32 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
-"""Tests for the :mod:`aiida_s3.repository.aws_s3` module."""
+"""Tests for the :mod:`aiida_s3.repository.s3` module."""
 import io
 import typing as t
 import uuid
 
 import pytest
 
-from aiida_s3.repository.aws_s3 import AwsS3RepositoryBackend
+from aiida_s3.repository.s3 import S3RepositoryBackend
 
 
 @pytest.fixture(scope='function')
-def repository_uninitialised(aws_s3_config) -> t.Generator[AwsS3RepositoryBackend, None, None]:
-    """Return uninitialised instance of :class:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend`."""
-    repository = AwsS3RepositoryBackend(bucket_name=str(uuid.uuid4()), **aws_s3_config)
+def repository_uninitialised(s3_config) -> t.Generator[S3RepositoryBackend, None, None]:
+    """Return uninitialised instance of :class:`aiida_s3.repository.s3.S3RepositoryBackend`."""
+    repository = S3RepositoryBackend(bucket_name=str(uuid.uuid4()), **s3_config)
     yield repository
 
 
 @pytest.fixture(scope='function')
-def repository(aws_s3_bucket_name, aws_s3_config) -> t.Generator[AwsS3RepositoryBackend, None, None]:
-    """Return initialised instance of :class:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend`."""
-    repository = AwsS3RepositoryBackend(bucket_name=aws_s3_bucket_name, **aws_s3_config)
+def repository(s3_bucket_name, s3_config) -> t.Generator[S3RepositoryBackend, None, None]:
+    """Return initialised instance of :class:`aiida_s3.repository.s3.S3RepositoryBackend`."""
+    repository = S3RepositoryBackend(bucket_name=s3_bucket_name, **s3_config)
     repository.initialise()
     yield repository
 
 
 def test_initialise(repository_uninitialised):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.initialise` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.initialise` method."""
     repository = repository_uninitialised
     assert not repository.is_initialised
 
@@ -39,17 +39,17 @@ def test_initialise(repository_uninitialised):
 
 
 def test_uuid(repository):
-    """Test the :prop:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.uuid` property."""
+    """Test the :prop:`aiida_s3.repository.s3.S3RepositoryBackend.uuid` property."""
     assert repository.uuid == repository._bucket_name  # pylint: disable=protected-access
 
 
 def test_key_format(repository):
-    """Test the :prop:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.key_format` property."""
+    """Test the :prop:`aiida_s3.repository.s3.S3RepositoryBackend.key_format` property."""
     assert repository.key_format == 'uuid4'
 
 
 def test_erase(repository, generate_directory):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.erase` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.erase` method."""
     directory = generate_directory({'file_a': None})
 
     with open(directory / 'file_a', 'rb') as handle:
@@ -63,7 +63,7 @@ def test_erase(repository, generate_directory):
 
 
 def test_erase_uninitialised(repository_uninitialised):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.erase` method for uninitialised repo.
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.erase` method for uninitialised repo.
 
     The method should not fail if the configure bucket does not exist.
     """
@@ -71,7 +71,7 @@ def test_erase_uninitialised(repository_uninitialised):
 
 
 def test_put_object_from_filelike_raises(repository, generate_directory):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.put_object_from_filelike`.
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.put_object_from_filelike`.
 
     Test invocations for which the method should raise an exception.
     """
@@ -89,7 +89,7 @@ def test_put_object_from_filelike_raises(repository, generate_directory):
 
 
 def test_put_object_from_filelike(repository, generate_directory):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.put_object_from_filelike` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.put_object_from_filelike` method."""
     directory = generate_directory({'file_a': None})
 
     with open(directory / 'file_a', 'rb') as handle:
@@ -99,7 +99,7 @@ def test_put_object_from_filelike(repository, generate_directory):
 
 
 def test_has_objects(repository, generate_directory):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.has_objects` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.has_objects` method."""
     directory = generate_directory({'file_a': None})
 
     assert repository.has_objects(['non_existant']) == [False]
@@ -111,7 +111,7 @@ def test_has_objects(repository, generate_directory):
 
 
 def test_open_raise(repository):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.open` method.
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.open` method.
 
     Test invocations for which the method should raise an exception.
     """
@@ -121,7 +121,7 @@ def test_open_raise(repository):
 
 
 def test_open(repository, generate_directory):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.open` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.open` method."""
     directory = generate_directory({'file_a': b'content_a', 'relative': {'file_b': b'content_b'}})
 
     with open(directory / 'file_a', 'rb') as handle:
@@ -141,7 +141,7 @@ def test_open(repository, generate_directory):
 
 
 def test_iter_object_streams(repository):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.iter_object_streams` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.iter_object_streams` method."""
     key = repository.put_object_from_filelike(io.BytesIO(b'content'))
 
     for _key, stream in repository.iter_object_streams([key]):
@@ -150,7 +150,7 @@ def test_iter_object_streams(repository):
 
 
 def test_delete_objects(repository, generate_directory):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.delete_objects` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.delete_objects` method."""
     directory = generate_directory({'file_a': None})
 
     with open(directory / 'file_a', 'rb') as handle:
@@ -166,7 +166,7 @@ def test_delete_objects(repository, generate_directory):
 
 
 def test_get_object_hash(repository, generate_directory):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.get_object_hash` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.get_object_hash` method."""
     directory = generate_directory({'file_a': b'content'})
 
     with open(directory / 'file_a', 'rb') as handle:
@@ -176,7 +176,7 @@ def test_get_object_hash(repository, generate_directory):
 
 
 def test_list_objects(repository, generate_directory):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.list_objects` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.list_objects` method."""
     keys = []
 
     # First empty the repository because other tests may have added objects to it.
@@ -195,10 +195,10 @@ def test_list_objects(repository, generate_directory):
 
 
 def test_get_info(repository):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.get_info` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.get_info` method."""
     assert repository.get_info() == {}
 
 
 def test_maintain(repository):
-    """Test the :meth:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.maintain` method."""
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.maintain` method."""
     assert repository.maintain() == {}

--- a/tests/static/config/psql_s3.yml
+++ b/tests/static/config/psql_s3.yml
@@ -1,0 +1,12 @@
+---
+profile_name: 'psql-s3'
+postgresql_engine: 'postgresql_psycopg2'
+postgresql_hostname : 'localhost'
+postgresql_port : 5432
+postgresql_username: 'aiida'
+postgresql_password : 'password'
+postgresql_database_name: 'aiida_psql_s3'
+endpoint_url: 'http://localhost:9000'
+access_key_id: 'access-key-id'
+secret_access_key: 'secret-access-key'
+bucket_name : 'aiida-s3-bucket'


### PR DESCRIPTION
The S3 protocol has become so widely adopted that its interface has become a standard. Besides the implementation of AWS, there are now open source implementations that implement the same interface, for example minIO (https://min.io/).

The existing implementation of the `AwsS3RepositoryBackend` class could be used for most of these other S3 implementations as long as the endpoint URL of the server can be specified.

Therefore the `AwsS3RepositoryBackend` implementation is moved to the `S3RepositoryBackend` which now serves as the base class. It adds the `endpoint_url` configuration parameter and removes the `region_name`, which is an AWS S3 specific option.

The other repository interface implementations now simply subclass the `S3RepositoryBackend` class and modify what is needed. The same goes for the storage classes: the `PsqlS3Storage` class now serves as a base implementation that is subclassed by adapters for AWS S3 and Azure Blob Storage.

The new `S3RepositoryBackend` is tested in the CI workflow against a minIO service. Note that the `minio/minio:edge-cicd` tag had to be used instead of the base image since for the latter the connection to the service always failed, for an unknown reason.