### PR TITLE
Fix s3 open()

### DIFF
--- a/src/aiida_s3/repository/s3.py
+++ b/src/aiida_s3/repository/s3.py
@@ -126,8 +126,8 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
                 self._client.download_fileobj(self._bucket_name, key, handle)
                 handle.seek(0)
                 yield handle
-        except botocore.exceptions.ClientError:
-            raise FileNotFoundError(f'object with key `{key}` does not exist.')
+        except botocore.exceptions.ClientError as exception:
+            raise FileNotFoundError(f'object with key `{key}` does not exist.') from exception
 
     def iter_object_streams(self, keys: list[str]) -> t.Iterator[tuple[str, t.IO[bytes]]]:  # type: ignore[override]
         """Return an iterator over the (read-only) byte streams of objects identified by key.

--- a/src/aiida_s3/repository/s3.py
+++ b/src/aiida_s3/repository/s3.py
@@ -121,11 +121,13 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
         :raise FileNotFoundError: if the file does not exist.
         :raise OSError: if the file could not be opened.
         """
-        super().open(key)
-        with tempfile.TemporaryFile() as handle:
-            self._client.download_fileobj(self._bucket_name, key, handle)
-            handle.seek(0)
-            yield handle
+        try:
+            with tempfile.TemporaryFile() as handle:
+                self._client.download_fileobj(self._bucket_name, key, handle)
+                handle.seek(0)
+                yield handle
+        except botocore.exceptions.ClientError:
+            raise FileNotFoundError(f'object with key `{key}` does not exist.')
 
     def iter_object_streams(self, keys: list[str]) -> t.Iterator[tuple[str, t.IO[bytes]]]:  # type: ignore[override]
         """Return an iterator over the (read-only) byte streams of objects identified by key.


### PR DESCRIPTION
"file exist" operation now is performed with boto3's head_object
before it was using list_object, that by default returns 1000 objects at maximum. The requested (existing) key may not be in the returned list. In any case the maximum number of objects must be known in advance, and listing all objects is a waste of resources.

solves https://github.com/sphuber/aiida-s3/issues/11

Some points to discuss on my side:
 - call or not call super().open(key)? In principle I think it should be called, but the additional test on file existence is a waste of communication. If this line is removed this implementation works in the same way and is more efficient.
 - we can possibly find a way to implement list_objects to list all the objects in the bucket, but this may be useless and expensive for the server. Is this feature needed anywhere?