### PR TITLE
`S3RepositoryBackend`: Remove double request in `list_objects`

### DIFF
--- a/src/aiida_s3/repository/s3.py
+++ b/src/aiida_s3/repository/s3.py
@@ -162,7 +162,7 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
         if 'Contents' not in response:
             yield from ()
         else:
-            for obj in self._client.list_objects(Bucket=self._bucket_name)['Contents']:
+            for obj in response['Contents']:
                 yield obj['Key']
 
     def maintain(  # type: ignore[override]


### PR DESCRIPTION
Fixes #16 

The result of the request was already assigned to a variable but then not reused and the same call was made a second time.