### PR TITLE
`S3RepositoryBackend`: Fix bug in `list_objects` being incomplete

### DIFF
--- a/src/aiida_s3/repository/s3.py
+++ b/src/aiida_s3/repository/s3.py
@@ -159,12 +159,16 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
 
         :return: An iterable for all the available object keys.
         """
-        response = self._client.list_objects(Bucket=self._bucket_name)
+        kwargs = {'Bucket': self._bucket_name}
+        paginator = self._client.get_paginator('list_objects_v2')
 
-        if 'Contents' not in response:
-            yield from ()
-        else:
-            for obj in response['Contents']:
+        for page in paginator.paginate(**kwargs):
+            try:
+                contents = page['Contents']
+            except KeyError:
+                break
+
+            for obj in contents:
                 yield obj['Key']
 
     def maintain(  # type: ignore[override]

--- a/tests/repository/test_s3.py
+++ b/tests/repository/test_s3.py
@@ -194,6 +194,34 @@ def test_list_objects(repository, generate_directory):
     assert sorted(list(repository.list_objects())) == sorted(keys)
 
 
+def test_list_objects_empty(repository):
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.list_objects` method for an empty repository."""
+    # First empty the repository because other tests may have added objects to it.
+    repository.erase()
+    repository.initialise()
+    assert not list(repository.list_objects())
+
+
+def test_list_objects_many(repository):
+    """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.list_objects` method for many existing objects.
+
+    The ``boto3.client.list_objects_v2`` method will not return all objects by default but results are paginated. The
+    default page size is a 1000, so here we test creating a repo with more than a 1000 and check that ``list_objects``
+    returns all of them.
+    """
+    keys = []
+
+    # First empty the repository because other tests may have added objects to it.
+    repository.erase()
+    repository.initialise()
+
+    # Create more than 1000 objects to ensure there are at least two pages of results.
+    for _ in range(1010):
+        keys.append(repository.put_object_from_filelike(io.BytesIO(b'a')))
+
+    assert sorted(list(repository.list_objects())) == sorted(keys)
+
+
 def test_get_info(repository):
     """Test the :meth:`aiida_s3.repository.s3.S3RepositoryBackend.get_info` method."""
     assert repository.get_info() == {}


### PR DESCRIPTION
Fixes #15 

The implementation of the `list_objects` method is incorrect since it only performs a single call and the `boto3` client by default only returns the first 1000 keys and pagination should be used to retrieve all objects for buckets that contain more objects than this page size.

The `list_objects` method is replaced with `list_objects_v2` since the latter is essentially deprecated and just kept for backwards compatibility. The implementation now also uses a paginator to yield the keys from all objects.