### PR TITLE
Devops: Update pre-commit configuration

### DIFF
--- a/.github/workflows/validate_release_tag.py
+++ b/.github/workflows/validate_release_tag.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Validate that the version in the tag label matches the version of the package."""
 import argparse
 import ast
@@ -17,8 +16,11 @@ def get_version_from_module(content: str) -> str:
 
     try:
         return next(
-            ast.literal_eval(statement.value) for statement in module.body if isinstance(statement, ast.Assign)
-            for target in statement.targets if isinstance(target, ast.Name) and target.id == '__version__'
+            ast.literal_eval(statement.value)
+            for statement in module.body
+            if isinstance(statement, ast.Assign)
+            for target in statement.targets
+            if isinstance(target, ast.Name) and target.id == '__version__'
         )
     except StopIteration as exception:
         raise IOError('Unable to find the `__version__` attribute in the module.') from exception

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,56 +1,40 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
-    hooks:
-    -   id: double-quote-string-fixer
-    -   id: end-of-file-fixer
-    -   id: fix-encoding-pragma
-    -   id: mixed-line-ending
-    -   id: trailing-whitespace
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: 'v4.5.0'
+  hooks:
+  - id: check-merge-conflict
+  - id: check-yaml
+  - id: end-of-file-fixer
+  - id: fix-encoding-pragma
+    args: [--remove]
+  - id: mixed-line-ending
+    args: [--fix=lf]
+  - id: trailing-whitespace
 
--   repo: https://github.com/ikamensh/flynt/
-    rev: '0.76'
-    hooks:
-    -   id: flynt
+- repo: https://github.com/ikamensh/flynt/
+  rev: '1.0.1'
+  hooks:
+  - id: flynt
 
--   repo: https://github.com/pycqa/isort
-    rev: '5.12.0'
-    hooks:
-    -   id: isort
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: 'v0.1.5'
+  hooks:
+  - id: ruff-format
+  - id: ruff
+    args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
--   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.32.0
-    hooks:
-    -   id: yapf
-        name: yapf
-        types: [python]
-        args: ['-i']
-        additional_dependencies: ['toml']
-
--   repo: https://github.com/PyCQA/pylint
-    rev: v2.12.2
-    hooks:
-    -   id: pylint
-        language: system
-
--   repo: https://github.com/PyCQA/pydocstyle
-    rev: '6.1.1'
-    hooks:
-    -   id: pydocstyle
-        additional_dependencies: ['toml']
-
--   repo: local
-    hooks:
-    -   id: mypy
-        name: mypy
-        entry: mypy
-        args: [--config-file=pyproject.toml]
-        language: python
-        types: [python]
-        require_serial: true
-        pass_filenames: true
-        files: >-
-            (?x)^(
-                src/.*py|
-                tests/.*py|
-            )$
+- repo: local
+  hooks:
+  - id: mypy
+    name: mypy
+    entry: mypy
+    args: [--config-file=pyproject.toml]
+    language: python
+    types: [python]
+    require_serial: true
+    pass_filenames: true
+    files: >-
+      (?x)^(
+        src/.*py|
+        tests/.*py|
+      )$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 keywords = ['aiida', 'workflows', 's3']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core~=2.2',
+    'aiida-core~=2.2,<2.4',
     'azure-storage-blob',
     'boto3',
 ]
@@ -41,8 +41,6 @@ tracker = 'https://github.com/sphuber/aiida-s3/issues'
 pre-commit = [
     'mypy==0.981',
     'pre-commit~=2.17',
-    'pylint~=2.12.2',
-    'pylint-aiida~=0.1.1',
     'types-pyyaml',
 ]
 tests = [
@@ -74,11 +72,28 @@ exclude = [
 line-length = 120
 fail-on-change = true
 
-[tool.isort]
-force_sort_within_sections = true
-include_trailing_comma = true
-line_length = 120
-multi_line_output = 3
+[tool.ruff]
+line-length = 120
+select = [
+    'E',    # pydocstyle
+    'W',    # pydocstyle
+    'F',    # pyflakes
+    'I',    # isort
+    'N',    # pep8-naming
+    'D',    # pydocstyle
+    'PLC',  # pylint-convention
+    'PLE',  # pylint-error
+    'PLR',  # pylint-refactor
+    'PLW',  # pylint-warning
+    'RUF',  # ruff
+]
+ignore = [
+    'D203',  # Incompatible with D211 `no-blank-line-before-class`
+    'D213',  # Incompatible with D212 `multi-line-summary-second-line`
+]
+
+[tool.ruff.format]
+quote-style = 'single'
 
 [tool.mypy]
 show_error_codes = true
@@ -88,7 +103,6 @@ warn_unused_ignores = true
 warn_redundant_casts = true
 no_warn_no_return = true
 show_traceback = true
-install-types = true
 
 [[tool.mypy.overrides]]
 module = 'aiida_s3.*'
@@ -96,6 +110,7 @@ check_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = [
+    'azure.*',
     'boto3.*',
     'botocore.*',
     'moto.*',
@@ -105,32 +120,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.pydocstyle]
-ignore = [
-    'D104',
-    'D203',
-    'D213'
-]
-
-[tool.pylint.basic]
-good-names = [
-    's3',
-]
-
-[tool.pylint.master]
-load-plugins = ['pylint_aiida']
-
-[tool.pylint.format]
-max-line-length = 120
-
-[tool.pylint.messages_control]
-disable = [
-    'bad-continuation',
-    'duplicate-code',
-    'import-outside-toplevel',
-    'too-many-arguments',
-]
-
 [tool.pytest.ini_options]
 filterwarnings = [
     'ignore:Creating AiiDA configuration folder.*:UserWarning'
@@ -138,12 +127,3 @@ filterwarnings = [
 markers = [
     'skip_if_azure_mocked: Skip if the Azure client is mocked, which is not supporte yet',
 ]
-
-[tool.yapf]
-align_closing_bracket_with_visual_indent = true
-based_on_style = 'google'
-coalesce_brackets = true
-column_limit = 120
-dedent_closing_brackets = true
-indent_dictionary_value = false
-split_arguments_when_comma_terminated = true

--- a/src/aiida_s3/__init__.py
+++ b/src/aiida_s3/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 """AiiDA plugin that provides a storage backend using an S3 object store as the file repository."""
 __version__ = '0.2.0'

--- a/src/aiida_s3/cli/__init__.py
+++ b/src/aiida_s3/cli/__init__.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=cyclic-import,wrong-import-position
 """Command line interface for ``aiida-s3``."""
-from aiida.cmdline.groups.verdi import VerdiCommandGroup
 import click
+from aiida.cmdline.groups.verdi import VerdiCommandGroup
 
 
 @click.group('aiida-s3', cls=VerdiCommandGroup)
@@ -10,4 +9,4 @@ def cmd_root():
     """Command line interface for ``aiida-s3``."""
 
 
-from .cmd_profile import cmd_profile
+from .cmd_profile import cmd_profile  # noqa

--- a/src/aiida_s3/cli/cmd_profile.py
+++ b/src/aiida_s3/cli/cmd_profile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """CLI commands to create profiles."""
 from aiida.cmdline.groups import DynamicEntryPointCommandGroup
 
@@ -10,7 +9,7 @@ def cmd_profile():
     """Commands to create profiles."""
 
 
-def create_profile(cls, non_interactive, **kwargs):  # pylint: disable=unused-argument
+def create_profile(cls, non_interactive, **kwargs):
     """Set up a new profile with an ``aiida-s3`` storage backend."""
     import contextlib
     import io
@@ -29,7 +28,7 @@ def create_profile(cls, non_interactive, **kwargs):  # pylint: disable=unused-ar
                 'database_username': kwargs.pop('postgresql_username'),
                 'database_password': kwargs.pop('postgresql_password'),
                 'database_name': kwargs.pop('postgresql_database_name'),
-            }
+            },
         },
         'process_control': {
             'backend': 'rabbitmq',
@@ -39,8 +38,8 @@ def create_profile(cls, non_interactive, **kwargs):  # pylint: disable=unused-ar
                 'broker_password': 'guest',
                 'broker_host': '127.0.0.1',
                 'broker_port': 5672,
-                'broker_virtual_host': ''
-            }
+                'broker_virtual_host': '',
+            },
         },
     }
 
@@ -58,7 +57,7 @@ def create_profile(cls, non_interactive, **kwargs):  # pylint: disable=unused-ar
     try:
         with contextlib.redirect_stdout(io.StringIO()):
             profile.storage_cls.initialise(profile)
-    except Exception as exception:  # pylint: disable=broad-except
+    except Exception as exception:
         echo.echo_critical(
             f'Storage backend initialisation failed, probably because connection details are incorrect:\n{exception}'
         )
@@ -74,7 +73,7 @@ def create_profile(cls, non_interactive, **kwargs):  # pylint: disable=unused-ar
     cls=DynamicEntryPointCommandGroup,
     command=create_profile,
     entry_point_group='aiida.storage',
-    entry_point_name_filter=r's3\..*'
+    entry_point_name_filter=r's3\..*',
 )
 def cmd_profile_setup():
     """Set up a new profile with an ``aiida-s3`` storage backend."""

--- a/src/aiida_s3/repository/__init__.py
+++ b/src/aiida_s3/repository/__init__.py
@@ -1,0 +1,1 @@
+"""Custom implementations of :class:`aiida.repository.backend.abstract.AbstractRepositoryBackend`."""

--- a/src/aiida_s3/repository/aws_s3.py
+++ b/src/aiida_s3/repository/aws_s3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Implementation of the :py:`aiida.repository.backend.abstract.AbstractRepositoryBackend` using AWS S3 as backend."""
 from __future__ import annotations
 
@@ -24,7 +23,6 @@ class AwsS3RepositoryBackend(S3RepositoryBackend):
         :param region_name: The AWS region name to create the bucket in if it doesn't yet exist.
         :param bucket_name: The name of the bucket to use.
         """
-        # pylint: disable=super-init-not-called
         self._bucket_name = bucket_name
         self._region_name = region_name
         self._client = boto3.client(

--- a/src/aiida_s3/repository/azure_blob.py
+++ b/src/aiida_s3/repository/azure_blob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Implementation of the :py:`aiida.repository.backend.abstract.AbstractRepositoryBackend` using Azure Blob Storage."""
 from __future__ import annotations
 
@@ -122,7 +121,7 @@ class AzureBlobStorageRepositoryBackend(AbstractRepositoryBackend):
         with tempfile.TemporaryFile(mode='w+b') as handle:
             try:
                 self._container_client.download_blob(key).readinto(handle)
-            except Exception as exception:  # pylint: disable=broad-except
+            except Exception as exception:
                 raise FileNotFoundError(f'object with key `{key}` does not exist.') from exception
             handle.seek(0)
             yield handle
@@ -160,16 +159,15 @@ class AzureBlobStorageRepositoryBackend(AbstractRepositoryBackend):
         for name in self._container_client.list_blob_names():
             yield name
 
-    def maintain(  # type: ignore[override]
+    def maintain(  # type: ignore[override]  # noqa: PLR0913
         self,
         dry_run: bool = False,
         live: bool = True,
-        pack_loose: bool = None,
-        do_repack: bool = None,
-        clean_storage: bool = None,
-        do_vacuum: bool = None,
+        pack_loose: bool | None = None,
+        do_repack: bool | None = None,
+        clean_storage: bool | None = None,
+        do_vacuum: bool | None = None,
     ) -> dict:
-        # pylint: disable=arguments-differ, unused-argument
         """Perform maintenance operations.
 
         :param live: if True, will only perform operations that are safe to do while the repository is in use.
@@ -185,6 +183,5 @@ class AzureBlobStorageRepositoryBackend(AbstractRepositoryBackend):
         self,
         detailed=False,
     ) -> dict[str, int | str | dict[str, int] | dict[str, float]]:
-        # pylint: disable=arguments-differ, unused-argument
         """Return information on configuration and content of the repository."""
         return {}

--- a/src/aiida_s3/repository/s3.py
+++ b/src/aiida_s3/repository/s3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Implementation of the :py:`aiida.repository.backend.abstract.AbstractRepositoryBackend` using S3 as backend."""
 from __future__ import annotations
 
@@ -7,9 +6,9 @@ import tempfile
 import typing as t
 import uuid
 
-from aiida.repository.backend.abstract import AbstractRepositoryBackend
 import boto3
 import botocore
+from aiida.repository.backend.abstract import AbstractRepositoryBackend
 
 __all__ = ('S3RepositoryBackend',)
 
@@ -171,16 +170,15 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
             for obj in contents:
                 yield obj['Key']
 
-    def maintain(  # type: ignore[override]
+    def maintain(  # type: ignore[override]  # noqa: PLR0913
         self,
         dry_run: bool = False,
         live: bool = True,
-        pack_loose: bool = None,
-        do_repack: bool = None,
-        clean_storage: bool = None,
-        do_vacuum: bool = None,
+        pack_loose: bool | None = None,
+        do_repack: bool | None = None,
+        clean_storage: bool | None = None,
+        do_vacuum: bool | None = None,
     ) -> dict:
-        # pylint: disable=arguments-differ, unused-argument
         """Perform maintenance operations.
 
         :param live: if True, will only perform operations that are safe to do while the repository is in use.
@@ -196,6 +194,5 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
         self,
         detailed=False,
     ) -> dict[str, int | str | dict[str, int] | dict[str, float]]:
-        # pylint: disable=arguments-differ, unused-argument
         """Return information on configuration and content of the repository."""
         return {}

--- a/src/aiida_s3/storage/__init__.py
+++ b/src/aiida_s3/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Custom implementations of :class:`aiida.orm.implementation.storage_backend.StorageBackend`."""

--- a/src/aiida_s3/storage/psql_aws_s3.py
+++ b/src/aiida_s3/storage/psql_aws_s3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + AWS S3."""
 from __future__ import annotations
 

--- a/src/aiida_s3/storage/psql_azure_blob.py
+++ b/src/aiida_s3/storage/psql_azure_blob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + Azure."""
 from __future__ import annotations
 
@@ -60,7 +59,7 @@ class PsqlAzureBlobStorage(BasePsqlDosBackend):
                     'type': str,
                     'prompt': 'Connection string',
                     'help': 'The Azure Blob Storage connection string.',
-                }
+                },
             }
         )
         return options

--- a/src/aiida_s3/storage/psql_dos.py
+++ b/src/aiida_s3/storage/psql_dos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + AWS S3."""
 from __future__ import annotations
 
@@ -18,6 +17,7 @@ class BasePsqlDosBackend(PsqlDosBackend):
         :return: The entry point or ``None`` if not found.
         """
         from aiida.plugins.entry_point import get_entry_point_from_class
+
         return get_entry_point_from_class(cls.__module__, cls.__name__)[1]
 
     @classmethod
@@ -73,5 +73,5 @@ class BasePsqlDosBackend(PsqlDosBackend):
                 'type': str,
                 'prompt': 'Postgresql database name',
                 'help': 'The name of the database in the PostgreSQL server.',
-            }
+            },
         }

--- a/src/aiida_s3/storage/psql_s3.py
+++ b/src/aiida_s3/storage/psql_s3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Implementation of :class:`aiida.orm.implementation.storage_backend.StorageBackend` using PostgreSQL + S3."""
 from __future__ import annotations
 

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_s3.cli.cmd_profile` module."""
 import pathlib
 
-from aiida.plugins import StorageFactory
 import pytest
 import yaml
+from aiida.plugins import StorageFactory
 
 
 def filepath_config():

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_s3.cli` module."""
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
 """Test fixtures for the :mod:`aiida_s3` module."""
 from __future__ import annotations
@@ -13,14 +12,14 @@ import types
 import typing as t
 import uuid
 
-from aiida.manage.configuration.profile import Profile
 import boto3
 import botocore
 import click
 import moto
 import pytest
+from aiida.manage.configuration.profile import Profile
 
-pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
+pytest_plugins = ['aiida.manage.tests.pytest_fixtures']
 
 
 def recursive_merge(left: dict[t.Any, t.Any], right: dict[t.Any, t.Any]) -> None:
@@ -30,7 +29,7 @@ def recursive_merge(left: dict[t.Any, t.Any], right: dict[t.Any, t.Any]) -> None
     :param right: Dictionary to recurisvely merge on top of ``left`` dictionary.
     """
     for key, value in right.items():
-        if (key in left and isinstance(left[key], dict) and isinstance(value, dict)):
+        if key in left and isinstance(left[key], dict) and isinstance(value, dict):
             recursive_merge(left[key], value)
         else:
             left[key] = value
@@ -42,8 +41,11 @@ class CliResult:
 
     stderr_bytes: bytes
     stdout_bytes: bytes
-    exc_info: tuple[t.Type[BaseException], BaseException, types.TracebackType] | tuple[None, None,
-                                                                                       None] = (None, None, None)
+    exc_info: tuple[t.Type[BaseException], BaseException, types.TracebackType] | tuple[None, None, None] = (
+        None,
+        None,
+        None,
+    )
     exception: BaseException | None = None
     exit_code: int | None = 0
 
@@ -75,7 +77,7 @@ def run_cli_command():
         arguments: list[str] | None = None,
         base_command: click.Command = cmd_root,
         raises: bool = False,
-        use_subprocess: bool = True
+        use_subprocess: bool = True,
     ) -> CliResult:
         """Run the command and check the result.
 
@@ -97,7 +99,7 @@ def run_cli_command():
 
         if use_subprocess:
             command = [base_command.name] if base_command.name else []
-            command += (arguments or [])
+            command += arguments or []
 
             try:
                 completed_process = subprocess.run(command, capture_output=True, check=True)
@@ -462,8 +464,9 @@ def azure_blob_config(should_mock_azure_blob) -> dict:
         ``connection_string``.
     """
     return {
-        'connection_string':
-        os.getenv('AIIDA_S3_AZURE_BLOB_CONNECTION_STRING') if not should_mock_azure_blob else 'mocked',
+        'connection_string': os.getenv('AIIDA_S3_AZURE_BLOB_CONNECTION_STRING')
+        if not should_mock_azure_blob
+        else 'mocked',
     }
 
 
@@ -545,7 +548,7 @@ def psql_azure_blob_profile(
 def generate_directory(tmp_path: pathlib.Path) -> t.Callable:
     """Construct a temporary directory with some arbitrary file hierarchy in it."""
 
-    def _factory(metadata: dict = None) -> pathlib.Path:
+    def _factory(metadata: dict | None = None) -> pathlib.Path:
         """Construct the contents of the temporary directory based on the metadata mapping.
 
         :param: file object hierarchy to construct. Each key corresponds to either a directory or file to create. If the
@@ -578,7 +581,6 @@ def generate_directory(tmp_path: pathlib.Path) -> t.Callable:
         def create_files(basepath: pathlib.Path, data: dict):
             """Construct the files in data at the given basepath."""
             for key, values in data.items():
-
                 filepath = basepath / key
 
                 if isinstance(values, dict):

--- a/tests/repository/test_aws_s3.py
+++ b/tests/repository/test_aws_s3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_s3.repository.aws_s3` module."""
 import io
@@ -6,7 +5,6 @@ import typing as t
 import uuid
 
 import pytest
-
 from aiida_s3.repository.aws_s3 import AwsS3RepositoryBackend
 
 
@@ -40,7 +38,7 @@ def test_initialise(repository_uninitialised):
 
 def test_uuid(repository):
     """Test the :prop:`aiida_s3.repository.aws_s3.AwsS3RepositoryBackend.uuid` property."""
-    assert repository.uuid == repository._bucket_name  # pylint: disable=protected-access
+    assert repository.uuid == repository._bucket_name
 
 
 def test_key_format(repository):

--- a/tests/repository/test_azure_blob.py
+++ b/tests/repository/test_azure_blob.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_s3.repository.azure_blob` module."""
 import io
@@ -6,7 +5,6 @@ import typing as t
 import uuid
 
 import pytest
-
 from aiida_s3.repository.azure_blob import AzureBlobStorageRepositoryBackend
 
 pytestmark = pytest.mark.skip_if_azure_mocked
@@ -48,7 +46,7 @@ def test_initialise(repository_uninitialised):
 
 def test_uuid(repository):
     """Test the :prop:`aiida_s3.repository.azure_blob.AzureBlobStorageRepositoryBackend.uuid` property."""
-    assert repository.uuid == repository._container_name  # pylint: disable=protected-access
+    assert repository.uuid == repository._container_name
 
 
 def test_key_format(repository):

--- a/tests/repository/test_s3.py
+++ b/tests/repository/test_s3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_s3.repository.s3` module."""
 import io
@@ -6,7 +5,6 @@ import typing as t
 import uuid
 
 import pytest
-
 from aiida_s3.repository.s3 import S3RepositoryBackend
 
 
@@ -40,7 +38,7 @@ def test_initialise(repository_uninitialised):
 
 def test_uuid(repository):
     """Test the :prop:`aiida_s3.repository.s3.S3RepositoryBackend.uuid` property."""
-    assert repository.uuid == repository._bucket_name  # pylint: disable=protected-access
+    assert repository.uuid == repository._bucket_name
 
 
 def test_key_format(repository):

--- a/tests/storage/test_psql_aws_s3.py
+++ b/tests/storage/test_psql_aws_s3.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_s3.storage.psql_aws_s3` module."""
 import io
 
-from aiida import orm
 import pytest
-
+from aiida import orm
 from aiida_s3.repository.aws_s3 import AwsS3RepositoryBackend
 from aiida_s3.storage.psql_aws_s3 import PsqlAwsS3Storage
 

--- a/tests/storage/test_psql_azure_blob.py
+++ b/tests/storage/test_psql_azure_blob.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
 """Tests for the :mod:`aiida_s3.storage.psql_azure_blob` module."""
 import io
 
-from aiida import orm
 import pytest
-
+from aiida import orm
 from aiida_s3.repository.azure_blob import AzureBlobStorageRepositoryBackend
 from aiida_s3.storage.psql_azure_blob import PsqlAzureBlobStorage
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`tests.conftest` module."""
 from botocore.client import BaseClient
 
@@ -6,4 +5,4 @@ from botocore.client import BaseClient
 def test_s3_client(aws_s3_client, aws_s3_config):
     """Test the ``aws_s3_client`` fixture."""
     assert isinstance(aws_s3_client, BaseClient)
-    assert str(aws_s3_client._endpoint) == f's3(https://s3.{aws_s3_config["region_name"]}.amazonaws.com)'  # pylint: disable=protected-access
+    assert str(aws_s3_client._endpoint) == f's3(https://s3.{aws_s3_config["region_name"]}.amazonaws.com)'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_s3` module."""
-from packaging.version import Version, parse
-
 import aiida_s3
+from packaging.version import Version, parse
 
 
 def test_version():


### PR DESCRIPTION
* Drop `yapf`, `isort`, `pylint` and `pydocstyle` in favor of `ruff`
* Remove all encoding pragma, only necessary for Python 2