### PR TITLE
Devops: Update dependency requirement `mypy==1.7.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,5 +44,4 @@ repos:
     files: >-
       (?x)^(
         src/.*py|
-        tests/.*py|
       )$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = '>=3.9'
 
 [project.optional-dependencies]
 pre-commit = [
-  'mypy==0.981',
+  'mypy==1.8.0',
   'pre-commit~=2.17',
   'types-pyyaml'
 ]
@@ -72,17 +72,11 @@ fail-on-change = true
 line-length = 120
 
 [tool.mypy]
-check_untyped_defs = true
-no_warn_no_return = true
-scripts_are_modules = true
-show_error_codes = true
-show_traceback = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-
-[[tool.mypy.overrides]]
-check_untyped_defs = true
-module = 'aiida_s3.*'
+disallow_untyped_calls = false
+exclude = [
+  '^tests/'
+]
+strict = true
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true

--- a/src/aiida_s3/cli/__init__.py
+++ b/src/aiida_s3/cli/__init__.py
@@ -5,7 +5,7 @@ from aiida.cmdline.groups.verdi import VerdiCommandGroup
 
 
 @click.group('aiida-s3', cls=VerdiCommandGroup)
-def cmd_root():
+def cmd_root() -> None:
     """Command line interface for ``aiida-s3``."""
 
 

--- a/src/aiida_s3/cli/cmd_profile.py
+++ b/src/aiida_s3/cli/cmd_profile.py
@@ -10,12 +10,12 @@ if t.TYPE_CHECKING:
     from aiida.orm.implementation.storage_backend import StorageBackend
 
 
-@cmd_root.group('profile')  # type: ignore[has-type]
-def cmd_profile():
+@cmd_root.group('profile')  # type: ignore[misc,has-type]
+def cmd_profile() -> None:
     """Commands to create profiles."""
 
 
-def create_profile(ctx: click.Context, cls: t.Type['StorageBackend'], non_interactive: bool, **kwargs):
+def create_profile(ctx: click.Context, cls: t.Type['StorageBackend'], non_interactive: bool, **kwargs: t.Any) -> None:
     """Set up a new profile with an ``aiida-s3`` storage backend."""
     import contextlib
     import io
@@ -81,12 +81,12 @@ def create_profile(ctx: click.Context, cls: t.Type['StorageBackend'], non_intera
     echo.echo_success(f'Created new profile `{profile.name}`.')
 
 
-@cmd_profile.group(
+@cmd_profile.group(  # type: ignore[misc]
     'setup',
     cls=DynamicEntryPointCommandGroup,
     command=create_profile,
     entry_point_group='aiida.storage',
     entry_point_name_filter=r's3\..*',
 )
-def cmd_profile_setup():
+def cmd_profile_setup() -> None:
     """Set up a new profile with an ``aiida-s3`` storage backend."""

--- a/src/aiida_s3/repository/aws_s3.py
+++ b/src/aiida_s3/repository/aws_s3.py
@@ -1,6 +1,8 @@
 """Implementation of the :py:`aiida.repository.backend.abstract.AbstractRepositoryBackend` using AWS S3 as backend."""
 from __future__ import annotations
 
+import typing as t
+
 import boto3
 
 from .s3 import S3RepositoryBackend
@@ -36,7 +38,7 @@ class AwsS3RepositoryBackend(S3RepositoryBackend):
         """Return the string representation of this repository."""
         return f'AwsS3RepositoryBackend: <{self._bucket_name}>'
 
-    def initialise(self, **kwargs) -> None:
+    def initialise(self, **kwargs: t.Any) -> None:
         """Initialise the repository if it hasn't already been initialised.
 
         :param kwargs: parameters for the initialisation.

--- a/src/aiida_s3/repository/azure_blob.py
+++ b/src/aiida_s3/repository/azure_blob.py
@@ -58,7 +58,7 @@ class AzureBlobStorageRepositoryBackend(AbstractRepositoryBackend):
         """
         return self._container_exists
 
-    def initialise(self, **kwargs) -> None:
+    def initialise(self, **kwargs: t.Any) -> None:
         """Initialise the repository if it hasn't already been initialised.
 
         :param kwargs: parameters for the initialisation.
@@ -78,7 +78,7 @@ class AzureBlobStorageRepositoryBackend(AbstractRepositoryBackend):
         """Return the format for the keys of the repository."""
         return 'uuid4'
 
-    def erase(self):
+    def erase(self) -> None:
         """Delete the container configured for this instance and all its contents."""
         if not self._container_exists:
             return
@@ -167,7 +167,7 @@ class AzureBlobStorageRepositoryBackend(AbstractRepositoryBackend):
         do_repack: bool | None = None,
         clean_storage: bool | None = None,
         do_vacuum: bool | None = None,
-    ) -> dict:
+    ) -> dict[str, t.Any]:
         """Perform maintenance operations.
 
         :param live: if True, will only perform operations that are safe to do while the repository is in use.
@@ -179,9 +179,6 @@ class AzureBlobStorageRepositoryBackend(AbstractRepositoryBackend):
         """
         return {}
 
-    def get_info(  # type: ignore[override]
-        self,
-        detailed=False,
-    ) -> dict[str, int | str | dict[str, int] | dict[str, float]]:
+    def get_info(self, detailed: bool = False, **kwargs: t.Any) -> dict[t.Any, t.Any]:
         """Return information on configuration and content of the repository."""
         return {}

--- a/src/aiida_s3/repository/s3.py
+++ b/src/aiida_s3/repository/s3.py
@@ -59,7 +59,7 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
         """
         return self._bucket_exists
 
-    def initialise(self, **kwargs) -> None:
+    def initialise(self, **kwargs: t.Any) -> None:
         """Initialise the repository if it hasn't already been initialised.
 
         :param kwargs: parameters for the initialisation.
@@ -79,7 +79,7 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
         """Return the format for the keys of the repository."""
         return 'uuid4'
 
-    def erase(self):
+    def erase(self) -> None:
         """Delete the bucket configured for this instance and all its contents."""
         if not self._bucket_exists:
             return
@@ -178,7 +178,7 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
         do_repack: bool | None = None,
         clean_storage: bool | None = None,
         do_vacuum: bool | None = None,
-    ) -> dict:
+    ) -> dict[t.Any, t.Any]:
         """Perform maintenance operations.
 
         :param live: if True, will only perform operations that are safe to do while the repository is in use.
@@ -190,9 +190,6 @@ class S3RepositoryBackend(AbstractRepositoryBackend):
         """
         return {}
 
-    def get_info(  # type: ignore[override]
-        self,
-        detailed=False,
-    ) -> dict[str, int | str | dict[str, int] | dict[str, float]]:
+    def get_info(self, detailed: bool = False, **kwargs: t.Any) -> dict[t.Any, t.Any]:
         """Return information on configuration and content of the repository."""
         return {}

--- a/src/aiida_s3/storage/psql_dos.py
+++ b/src/aiida_s3/storage/psql_dos.py
@@ -7,7 +7,7 @@ import typing as t
 from aiida.storage.psql_dos import PsqlDosBackend
 
 if t.TYPE_CHECKING:
-    from aiida.plugins.entry_point import EntryPoint
+    from importlib_metadata import EntryPoint
 
 
 class BasePsqlDosBackend(PsqlDosBackend):
@@ -24,12 +24,12 @@ class BasePsqlDosBackend(PsqlDosBackend):
         return get_entry_point_from_class(cls.__module__, cls.__name__)[1]
 
     @classmethod
-    def get_cli_options(cls) -> collections.OrderedDict:
+    def get_cli_options(cls) -> collections.OrderedDict[str, t.Any]:
         """Return the CLI options that would allow to create an instance of this class."""
         return collections.OrderedDict(cls._get_cli_options())
 
     @classmethod
-    def _get_cli_options(cls) -> dict:
+    def _get_cli_options(cls) -> dict[str, t.Any]:
         """Return the CLI options that would allow to create an instance of this class."""
         return {
             'profile_name': {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -535,13 +535,12 @@ def psql_azure_blob_profile(
     if should_mock_azure_blob:
         # Azure cannot yet be successfully mocked, so if we are mocking, skip the test.
         yield None
-        return
-
-    try:
-        yield aiida_profile_factory(config_psql_azure_blob())
-    finally:
-        repository = AzureBlobStorageRepositoryBackend(**azure_blob_storage)
-        repository.erase()
+    else:
+        try:
+            yield aiida_profile_factory(config_psql_azure_blob())
+        finally:
+            repository = AzureBlobStorageRepositoryBackend(**azure_blob_storage)
+            repository.erase()
 
 
 @pytest.fixture


### PR DESCRIPTION
The configuration is set to `strict` with the only exception of allowing untyped calls of dependency code, since that is impossible to control in this library itself. The `tests` directory is excluded.