### PR TITLE
Devops: Make use of the improved fixtures in `aiida-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   'Topic :: Scientific/Engineering'
 ]
 dependencies = [
-  'aiida-core~=2.5.0',
+  'aiida-core~=2.6',
   'azure-storage-blob',
   'boto3'
 ]

--- a/src/aiida_s3/storage/psql_aws_s3.py
+++ b/src/aiida_s3/storage/psql_aws_s3.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import typing as t
+
 from aiida.storage.psql_dos import PsqlDosBackend
 from pydantic import Field
 
@@ -32,7 +34,7 @@ class PsqlAwsS3Storage(PsqlDosBackend):
 
     migrator = PsqlAwsS3StorageMigrator
 
-    class Configuration(PsqlDosBackend.Configuration):
+    class Model(PsqlDosBackend.Model):
         """Model describing required information to configure an instance of the storage."""
 
         aws_access_key_id: str = Field(
@@ -51,6 +53,7 @@ class PsqlAwsS3Storage(PsqlDosBackend):
             title='AWS bucket name',
             description='The name of the AWS S3 bucket to use.',
         )
+        repository_uri: t.ClassVar[None]  # type: ignore[assignment,misc]
 
     def get_repository(self) -> AwsS3RepositoryBackend:  # type: ignore[override]
         """Return the file repository backend instance.

--- a/src/aiida_s3/storage/psql_azure_blob.py
+++ b/src/aiida_s3/storage/psql_azure_blob.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import typing as t
+
 from aiida.storage.psql_dos.backend import PsqlDosBackend
 from pydantic import Field
 
@@ -36,7 +38,7 @@ class PsqlAzureBlobStorage(PsqlDosBackend):
 
     migrator = PsqlAzureBlobStorageMigrator
 
-    class Configuration(PsqlDosBackend.Configuration):
+    class Model(PsqlDosBackend.Model):
         """Model describing required information to configure an instance of the storage."""
 
         container_name: str = Field(
@@ -47,6 +49,7 @@ class PsqlAzureBlobStorage(PsqlDosBackend):
             title='Connection string',
             description='The Azure Blob Storage connection string.',
         )
+        repository_uri: t.ClassVar[None]  # type: ignore[assignment,misc]
 
     def get_repository(self) -> AzureBlobStorageRepositoryBackend:  # type: ignore[override]
         """Return the file repository backend instance.

--- a/src/aiida_s3/storage/psql_s3.py
+++ b/src/aiida_s3/storage/psql_s3.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import typing as t
+
 from aiida.storage.psql_dos.backend import PsqlDosBackend
 from aiida.storage.psql_dos.migrator import PsqlDosMigrator
 from pydantic import Field
@@ -58,7 +60,7 @@ class PsqlS3Storage(PsqlDosBackend):
 
     migrator = PsqlS3StorageMigrator
 
-    class Configuration(PsqlDosBackend.Configuration):
+    class Model(PsqlDosBackend.Model):
         """Model describing required information to configure an instance of the storage."""
 
         endpoint_url: str = Field(
@@ -77,6 +79,7 @@ class PsqlS3Storage(PsqlDosBackend):
             title='Bucket name',
             description='The name of the S3 bucket to use.',
         )
+        repository_uri: t.ClassVar[None]  # type: ignore[assignment,misc]
 
     def get_repository(self) -> S3RepositoryBackend:  # type: ignore[override]
         """Return the file repository backend instance.


### PR DESCRIPTION
The fixtures now provide the `config_psql_dos` fixture with the
difference that it no longer provides the dictionary of an entire
profile but just the storage configuration. The new `tmp_aiida_profile`
is used to create a temporary profile with arbitrary storage on the fly.